### PR TITLE
Adding note about other pumps to HARDWARE.md

### DIFF
--- a/docs/Hardware/hardware.md
+++ b/docs/Hardware/hardware.md
@@ -2,6 +2,8 @@
 # Hardware
 This section describes the hardware components required for a 'typical' OpenAPS implementation. There are numerous variations and substitutions that can be made, but the following items are recommended for getting started. If you come across something that doesn't seem to work, is no longer available, or have a notable alternative, feel free to edit this document with your suggestions.
 
+(If you're interested in working on communication for another pump (Omnipod, etc.), email Dana (dana@OpenAPS.org) to be added to the collaboration group focusing on alternative pump communication.)
+
 
 ## Required  Hardware
 


### PR DESCRIPTION
Adding a note to start a funnel to send folks interested in other pumps to the right place vs. them turning away here completely. (I also added the same note to openaps.org recent blog post).