### PR TITLE
Added "not here" readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+#Docs / Docs
+
+This is not the main OpenAPS documentation directory. To switch to main Readme please click [here](../README.md)


### PR DESCRIPTION
I started to look into documentation starting from a wrong place and it was misleading for me. This is why I creaded a "not gere" readme.