### PR TITLE
Separate two commands into two lines rendered

### DIFF
--- a/docs/docs/walkthrough/phase-0/openaps.md
+++ b/docs/docs/walkthrough/phase-0/openaps.md
@@ -45,6 +45,7 @@ This installs a number of packages required by openaps.
 Run
 
 `sudo easy_install -ZU setuptools`
+
 `sudo easy_install -ZU openaps`
 
 Running this command will also update openaps on your system if a newer version is available.


### PR DESCRIPTION
This corrects the situation of two lines in the markdown showing up together as one line when rendered. 