### PR TITLE
Workaround for plugging in charged or uncharged dexcom receiver

### DIFF
--- a/docs/docs/walkthrough/phase-2/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-2/using-openaps-tools.md
@@ -169,7 +169,9 @@ Go ahead and try some more pump uses to find out what they do. Note that some of
 
 Now let's try communicating with the Dexcom receiver.
 
-Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged.
+Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged. 
+If you continue to have problems, try increasing the mA output to the USB Ports, you can do this by running the following command `sudo echo -e "#Enabled Max USB power https://www.hackster.io/idreams/boost-usb-current-in-raspberry-pi-a1531d
+\nmax_usb_current=1" > /boot/config.txt`. Reboot via `sudo shutdown -r now` to pick up the changes.
 
 `$ openaps use <my_dexcom_name> iter_glucose 1`
 

--- a/docs/docs/walkthrough/phase-2/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-2/using-openaps-tools.md
@@ -171,7 +171,8 @@ Now let's try communicating with the Dexcom receiver.
 
 Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged. 
 
-If you continue to have problems, try increasing the mA output to the USB Ports, you can do this by running the following command `sudo echo -e "#Enabled Max USB power\nmax_usb_current=1" >> /boot/config.txt`. Reboot via `sudo shutdown -r now` to pick up the changes.
+Workaround: If you continue to have problems, try increasing the mA output to the USB Ports, you can do this by running the following command `sudo bash -c "echo -e \"#Enabled Max USB power\nmax_usb_current=1\" >> /boot/config.txt"`. 
+Reboot via `sudo shutdown -r now` to pick up the changes.
 
 `$ openaps use <my_dexcom_name> iter_glucose 1`
 

--- a/docs/docs/walkthrough/phase-2/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-2/using-openaps-tools.md
@@ -171,8 +171,7 @@ Now let's try communicating with the Dexcom receiver.
 
 Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged. 
 
-If you continue to have problems, try increasing the mA output to the USB Ports, you can do this by running the following command `sudo echo -e "#Enabled Max USB power https://www.hackster.io/idreams/boost-usb-current-in-raspberry-pi-a1531d
-\nmax_usb_current=1" >> /boot/config.txt`. Reboot via `sudo shutdown -r now` to pick up the changes.
+If you continue to have problems, try increasing the mA output to the USB Ports, you can do this by running the following command `sudo echo -e "#Enabled Max USB power\nmax_usb_current=1" >> /boot/config.txt`. Reboot via `sudo shutdown -r now` to pick up the changes.
 
 `$ openaps use <my_dexcom_name> iter_glucose 1`
 

--- a/docs/docs/walkthrough/phase-2/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-2/using-openaps-tools.md
@@ -171,8 +171,9 @@ Now let's try communicating with the Dexcom receiver.
 
 Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged. 
 
-Workaround: If you continue to have problems, try increasing the mA output to the USB Ports, you can do this by running the following command `sudo bash -c "echo -e \"#Enabled Max USB power\nmax_usb_current=1\" >> /boot/config.txt"`. 
-Reboot via `sudo shutdown -r now` to pick up the changes.
+Workaround: If you continue to have problems, try increasing the mA output to the USB ports, you can do this by running the following command `$ sudo bash -c "echo -e \"#Enabled Max USB power\nmax_usb_current=1\" >> /boot/config.txt"`. 
+
+Reboot via `$ sudo shutdown -r now` to pick up the changes.
 
 `$ openaps use <my_dexcom_name> iter_glucose 1`
 

--- a/docs/docs/walkthrough/phase-2/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-2/using-openaps-tools.md
@@ -171,7 +171,7 @@ Now let's try communicating with the Dexcom receiver.
 
 Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged. 
 
-> Workaround: If you continue to have problems, try increasing the mA output to the USB ports, you can do this by running the following command `$ sudo bash -c "echo -e \"#Enabled Max USB power\nmax_usb_current=1\" >> /boot/config.txt"`. 
+> Workaround: If you continue to have problems, try increasing the mA output to the USB ports, you can do this by running the following command `$ sudo bash -c "echo -e \"#Enable Max USB power\nmax_usb_current=1\" >> /boot/config.txt"`. 
 
 > Reboot via `$ sudo shutdown -r now` to pick up the changes.
 

--- a/docs/docs/walkthrough/phase-2/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-2/using-openaps-tools.md
@@ -170,8 +170,9 @@ Go ahead and try some more pump uses to find out what they do. Note that some of
 Now let's try communicating with the Dexcom receiver.
 
 Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged. 
+
 If you continue to have problems, try increasing the mA output to the USB Ports, you can do this by running the following command `sudo echo -e "#Enabled Max USB power https://www.hackster.io/idreams/boost-usb-current-in-raspberry-pi-a1531d
-\nmax_usb_current=1" > /boot/config.txt`. Reboot via `sudo shutdown -r now` to pick up the changes.
+\nmax_usb_current=1" >> /boot/config.txt`. Reboot via `sudo shutdown -r now` to pick up the changes.
 
 `$ openaps use <my_dexcom_name> iter_glucose 1`
 

--- a/docs/docs/walkthrough/phase-2/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-2/using-openaps-tools.md
@@ -171,9 +171,8 @@ Now let's try communicating with the Dexcom receiver.
 
 Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged. 
 
-Workaround: If you continue to have problems, try increasing the mA output to the USB ports, you can do this by running the following command `$ sudo bash -c "echo -e \"#Enabled Max USB power\nmax_usb_current=1\" >> /boot/config.txt"`. 
-
-Reboot via `$ sudo shutdown -r now` to pick up the changes.
+> Workaround: If you continue to have problems, try increasing the mA output to the USB ports, you can do this by running the following command `$ sudo bash -c "echo -e \"#Enabled Max USB power\nmax_usb_current=1\" >> /boot/config.txt"`. 
+> Reboot via `$ sudo shutdown -r now` to pick up the changes.
 
 `$ openaps use <my_dexcom_name> iter_glucose 1`
 

--- a/docs/docs/walkthrough/phase-2/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-2/using-openaps-tools.md
@@ -172,6 +172,7 @@ Now let's try communicating with the Dexcom receiver.
 Hint: Your Dexcom should be nearly fully charged before plugging it in to your Raspberry Pi. If, when you plug in your Dexcom, it causes your WiFi dongle to stop blinking, that is a sign that it is drawing too much power and needs to be charged. 
 
 > Workaround: If you continue to have problems, try increasing the mA output to the USB ports, you can do this by running the following command `$ sudo bash -c "echo -e \"#Enabled Max USB power\nmax_usb_current=1\" >> /boot/config.txt"`. 
+
 > Reboot via `$ sudo shutdown -r now` to pick up the changes.
 
 `$ openaps use <my_dexcom_name> iter_glucose 1`


### PR DESCRIPTION
I continued to have a problem with plugging in the dexcom receiver regardless of charge level. This modification got it past the Rpi hangs and the endless loop of errors dumping into /var/log/messages