### PR TITLE
Remind to add 'careportal' to Nightscout

### DIFF
--- a/docs/docs/walkthrough/phase-1/visualization.md
+++ b/docs/docs/walkthrough/phase-1/visualization.md
@@ -118,7 +118,7 @@ Some things to be aware of:
 
 ### Uploading Latest Treatments to Nightscout
 
-Note: Remember to add `careportal` to Nigtscouts `ENABLE` environment variable in case it is not already there.
+Note: Remember to add `careportal` to Nightscout's `ENABLE` environment variable in case it is not already there.
 
 In addition to uloading OpenAPS status, it also very beneficial to upload the treatment information from the pump into Nightscout.  This removes the burden of entering this information into Nightscout manually. This can be accomplished using `nightscout` command and adding a new `upload-recent-treatments` alias as follows: 
 

--- a/docs/docs/walkthrough/phase-1/visualization.md
+++ b/docs/docs/walkthrough/phase-1/visualization.md
@@ -118,6 +118,8 @@ Some things to be aware of:
 
 ### Uploading Latest Treatments to Nightscout
 
+Note: Remember to add `careportal` to Nigtscouts `ENABLE` environment variable in case it is not already there.
+
 In addition to uloading OpenAPS status, it also very beneficial to upload the treatment information from the pump into Nightscout.  This removes the burden of entering this information into Nightscout manually. This can be accomplished using `nightscout` command and adding a new `upload-recent-treatments` alias as follows: 
 
 ```


### PR DESCRIPTION
Uploading treatments requires environment variable 'ENABLE' to include 'careportal'.

After scratching my head for some time I've finally figure out why `POST` to `treatments` was not working. 