### PR TITLE
point openaps-contrib to master

### DIFF
--- a/scripts/quick-src.sh
+++ b/scripts/quick-src.sh
@@ -23,7 +23,7 @@ cd ~/src && \
     (cd openaps && \
         sudo python setup.py develop
     )
-    git clone -b dev git://github.com/openaps/openaps-contrib.git || \
+    git clone git://github.com/openaps/openaps-contrib.git || \
         (cd openaps-contrib && git pull)
     (cd openaps-contrib && \
         sudo python setup.py develop


### PR DESCRIPTION
openaps-contrib git setup fails as it points to a dev branch that doesn't exist (any more?).  Changed it to get master. 