### PR TITLE
Fixing setup to generate settings/carb-ratios.json

### DIFF
--- a/docs/reference/openaps/openaps-report-settings-carb_ratios.md
+++ b/docs/reference/openaps/openaps-report-settings-carb_ratios.md
@@ -1,7 +1,7 @@
 #### `settings/carb_ratios.json`
 This report contains your carb ratios.
 ##### Setup code
-`openaps report add settings/model.json JSON pump read_carb_ratios`
+`openaps report add settings/carb-ratios.json JSON pump read_carb_ratios`
 ##### Sample contents
 `{
   "units": "grams", 


### PR DESCRIPTION
Original code would generate settings/model.json but actually contain the carb-ratios output. Caused some confusion on Gitter on 6/4.