### PR TITLE
Noting the "min_bg" value floor

### DIFF
--- a/docs/reference/openaps/openaps-report-settings-bg_targets.md
+++ b/docs/reference/openaps/openaps-report-settings-bg_targets.md
@@ -1,5 +1,5 @@
 #### `settings/bg_targets.json`
-This report contains the high/low glucose targets set up in your pump.
+This report contains the high/low glucose targets set up in your pump. OpenAPS has a hardcoded "min_bg" floor of 90, which will override any pump low target bg value below 90.
 ##### Setup code
 `openaps report add settings/bg_targets.json JSON pump read_bg_targets`
 ##### Sample contents


### PR DESCRIPTION
OpenAPS defaults min_bg to 90, overriding any pump setting with a lower min_bg value.