### PR TITLE
Clarifying target range and min_bg floor

### DIFF
--- a/docs/docs/walkthrough/phase-5/tuning-targets.md
+++ b/docs/docs/walkthrough/phase-5/tuning-targets.md
@@ -2,7 +2,7 @@
 
 After you adjust your max iob and go beyond low glucose suspend mode, run the system overnight under close observation with the following considerations around targets:
 
-* You should start with high targets and a good safety margin. For example, you might start with your target at 150 to see how the system does.
+* You should start with high targets and a good safety margin. For example, you might start with your target at 150 to see how the system does. OpenAPS has a "min" target floor which prevents you from setting it below 90.
 
 * Before adjusting your target, you should have at least one night with zero low alarms (in three days) before considering dropping the max target below 160.
 
@@ -10,4 +10,4 @@ After you adjust your max iob and go beyond low glucose suspend mode, run the sy
 
 If you are going low overnight for three+ days, your "min" target may need to be raised.
 
-After you tune your targets, min can be set to be equivalent of max. However, when you first start, start with a range (i.e. 150-160). 
+After you tune your targets, min can be set to be equivalent of max. However, when you first start, start with a 10-point range (i.e. 150-160). 


### PR DESCRIPTION
Clarifying that in early testing, BG targets should be a tight range (10 points), and noting the min_bg floor.