### PR TITLE
## The determine-basal process suggested change

### DIFF
--- a/docs/docs/walkthrough/phase-2/Using-oref0-tools.md
+++ b/docs/docs/walkthrough/phase-2/Using-oref0-tools.md
@@ -143,7 +143,7 @@ This process uses the IOB computed by `calculate-iob`, the current temp basal st
 * `glucose` reads several most recent BG values from CGM and stores them in glucose.json file:
   
   ```
-  $ openaps report add monitor/glucose.json JSON cgm iter_glucose 5
+  $ openaps report add monitor/glucose.json JSON <my_cgm_name> iter_glucose 5
   ```
 
 In this example, glucose.json will contain 5 most recent bg values. 


### PR DESCRIPTION
When you are told to add the monitor glucose report. the command given just assumed the cgm device was called cgm. I added my device as g5. In the initial adding device section it says name it as you want. So i suggest changing it to the same format as the pump.