### PR TITLE
Possible correction on preflight operator logic

### DIFF
--- a/docs/docs/walkthrough/phase-2/building-preflight-safety-checks.md
+++ b/docs/docs/walkthrough/phase-2/building-preflight-safety-checks.md
@@ -37,7 +37,7 @@ returns the current pump time stamp, such as "2016-01-09T10:47:56", if the syste
 Collecting all the error checking, a `preflight` alias could be defined as follows:
 
 ```
-$ openaps alias add preflight '! bash -c "rm -f monitor/clock.json && openaps report invoke monitor/clock.json 2>/dev/null && grep -q T monitor/clock.json && echo PREFLIGHT OK || (mm-stick warmup || sudo oref0-reset-usb; echo PREFLIGHT FAIL; sleep 120; exit 1)"'
+$ openaps alias add preflight '! bash -c "rm -f monitor/clock.json && openaps report invoke monitor/clock.json 2>/dev/null && grep -q T monitor/clock.json && (mm-stick warmup || sudo oref0-reset-usb) && echo PREFLIGHT OK || ( echo PREFLIGHT FAIL; sleep 120; exit 1)"'
 ```
 
 In this `preflight` example, a wait period of 120 seconds is added using `sleep` bash command if the USB ports have been reset in an attempt to revive the MM CareLink stick. This `preflight` example also shows how bash commands can be chained together with the bash && ("and") or || ("or") operators to execute different subsequent commands depending on the output code of a previous command (interpreted as "true" or "false").


### PR DESCRIPTION
I could be totally wrong here, but it seems like we needed this change in the preflight alias example.  It looks like if the clock-related check worked, it  would have outputted "PREFLIGHT OK" before ever running the  `mm-stick warmup` and the `sudo oref0-reset-usb` script.  Am I missing something here?