### PR TITLE
Remove possibly redundant clause in loop alias

### DIFF
--- a/docs/docs/walkthrough/phase-2/loop-and-retry-logic.md
+++ b/docs/docs/walkthrough/phase-2/loop-and-retry-logic.md
@@ -1,5 +1,5 @@
 # Running an open loop with oref0
 
-To pull all of oref0 together, you could create a "loop" alias that looks something like `openaps alias add loop '! bash -c "( openaps preflight && openaps gather && openaps enact) || echo No CGM data."'`. If you want to also add some retry logic to try again if something failed, you could then do something like `openaps alias add retry-loop '! bash -c "openaps preflight && until( ! mm-stick warmup || openaps loop); do sleep 5; done"'`.
+To pull all of oref0 together, you could create a "loop" alias that looks something like `openaps alias add loop '! bash -c "( openaps preflight && openaps gather && openaps enact) || echo LOOP FAILED."'`. If you want to also add some retry logic to try again if something failed, you could then do something like `openaps alias add retry-loop '! bash -c "openaps preflight && until( ! mm-stick warmup || openaps loop); do sleep 5; done"'`.
 
 Once all that is working and tested, you will have a command that can be run manually or on a schedule to collect data from the pump and cgm, calculate IOB and a temp basal suggestion, and then enact that on the pump. 

--- a/docs/docs/walkthrough/phase-2/loop-and-retry-logic.md
+++ b/docs/docs/walkthrough/phase-2/loop-and-retry-logic.md
@@ -1,5 +1,5 @@
 # Running an open loop with oref0
 
-To pull all of oref0 together, you could create a "loop" alias that looks something like `openaps alias add loop '! bash -c "openaps monitor-cgm 2>/dev/null && ( openaps preflight && openaps gather && openaps enact) || echo No CGM data."'`. If you want to also add some retry logic to try again if something failed, you could then do something like `openaps alias add retry-loop '! bash -c "openaps preflight && until( ! mm-stick warmup || openaps loop); do sleep 5; done"'`.
+To pull all of oref0 together, you could create a "loop" alias that looks something like `openaps alias add loop '! bash -c "( openaps preflight && openaps gather && openaps enact) || echo No CGM data."'`. If you want to also add some retry logic to try again if something failed, you could then do something like `openaps alias add retry-loop '! bash -c "openaps preflight && until( ! mm-stick warmup || openaps loop); do sleep 5; done"'`.
 
 Once all that is working and tested, you will have a command that can be run manually or on a schedule to collect data from the pump and cgm, calculate IOB and a temp basal suggestion, and then enact that on the pump. 


### PR DESCRIPTION
Again, I could be completely missing something here but it seems like running `monitor-cgm` on the left hand side isn't actually doing anything.  It would get the latest glucose entries only to have them deleted in the `preflight` step and then `monitor-cgm` would be run again inside of `gather`.  It's harmless I guess but possibly confusing?  Or again maybe I'm missing something.