### PR TITLE
cd to the correct directory when pulling oref0

### DIFF
--- a/scripts/quick-src.sh
+++ b/scripts/quick-src.sh
@@ -29,7 +29,7 @@ cd ~/src && \
         sudo python setup.py develop
     )
     git clone -b dev git://github.com/openaps/oref0.git || \
-        (cd openaps-contrib && git pull)
+        (cd oref0 && git pull)
 )
 test -d oref0 && \
 cd oref0 && \


### PR DESCRIPTION
Looks like it's accessing the wrong directory when trying to set up oref0.