### PR TITLE
Update using-openaps-tools (drop G4 with Share)

### DIFF
--- a/docs/docs/walkthrough/phase-1/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-1/using-openaps-tools.md
@@ -144,9 +144,13 @@ Support for G5 receiver is offered through the usb cable and configuring the
 `cgm` device with: `openaps use cgm config --G5`.
 
 ### G4 with Share
+**Note** the instructions below do not work for some users, please see the
+GitHub [issue](https://github.com/openaps/openxshareble/issues/5) for details.
+Affected users can still obtain glucose data via usb cable.
+
 Install BLE helpers:
 ```
-sudo pip install git+git://github.com/bewest/Adafruit_Python_BluefruitLE.git'#wip/bewest/custom-gatt-profile'
+sudo pip install git+git://github.com/bewest/Adafruit_Python_BluefruitLE.git@wip/bewest/custom-gatt-profile
 sudo pip install git+git://github.com/bewest/openxshareble.git
 # adds openxshareble as vendor
 openaps vendor add openxshareble

--- a/docs/docs/walkthrough/phase-1/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-1/using-openaps-tools.md
@@ -143,20 +143,6 @@ contained in the same openaps device.
 Support for G5 receiver is offered through the usb cable and configuring the
 `cgm` device with: `openaps use cgm config --G5`.
 
-### G4 with Share
-Install BLE helpers:
-```
-sudo pip install git+git://github.com/bewest/Adafruit_Python_BluefruitLE.git'#wip/bewest/custom-gatt-profile'
-sudo pip install git+git://github.com/bewest/openxshareble.git
-# adds openxshareble as vendor
-openaps vendor add openxshareble
-```
-
-Then set up cgm device this way:
-```
-openaps device add cgm openxshareble
-```
-
 ### Glucose Data
 Test ability to get data.
 

--- a/docs/docs/walkthrough/phase-1/using-openaps-tools.md
+++ b/docs/docs/walkthrough/phase-1/using-openaps-tools.md
@@ -143,6 +143,20 @@ contained in the same openaps device.
 Support for G5 receiver is offered through the usb cable and configuring the
 `cgm` device with: `openaps use cgm config --G5`.
 
+### G4 with Share
+Install BLE helpers:
+```
+sudo pip install git+git://github.com/bewest/Adafruit_Python_BluefruitLE.git'#wip/bewest/custom-gatt-profile'
+sudo pip install git+git://github.com/bewest/openxshareble.git
+# adds openxshareble as vendor
+openaps vendor add openxshareble
+```
+
+Then set up cgm device this way:
+```
+openaps device add cgm openxshareble
+```
+
 ### Glucose Data
 Test ability to get data.
 


### PR DESCRIPTION
I don't think G4 with Share is supported with current versions of Raspbian/BlueZ based on https://github.com/openaps/openxshareble/issues/5 and debugging in person with @bewest (please correct me if I'm mistaken).