### PR TITLE
Add note for enabling cron-5-minute-helper

### DIFF
--- a/docs/docs/walkthrough/phase-4/create-schedule.md
+++ b/docs/docs/walkthrough/phase-4/create-schedule.md
@@ -1,13 +1,17 @@
 ## Using cron to create a schedule for your loop
 
 You should use [cron](http://bit.ly/1QpJFk1) to create a schedule for your loop.
-Use `oref0 cron-5-minute-helper` to generate a simple cron job.  It
-can be imported into crontab using `oref0 cron-5-minute-helper
-do-loop | crontab -`.  By default, it will list a suggested cron job
-that runs once every 5 minutes.
+Use `oref0 cron-5-minute-helper` to generate a simple cron job. It can be
+imported into crontab using `oref0 cron-5-minute-helper do-loop | crontab -`. By
+default, it will list a suggested cron job that runs once every 5 minutes.
 
-The symbols to the left of the command indicate how often the command should run.  Each symbol represents a unit of time, as follows.  Putting / before a number means the command will run every time that unit of time passes.
+The symbols to the left of the command indicate how often the command should
+run. Each symbol represents a unit of time, as follows. Putting / before a
+number means the command will run every time that many units of time passes. The
+units are:
+```
 <Minute> <Hour> <Day_of_the_Month> <Month_of_the_Year> <Day_of_the_Week>
+```
 
 Here's an example:
 
@@ -30,3 +34,15 @@ Another example would be to use cron to automatically resolve git corruption iss
 
 It prepares a cron template to change to the current directory and runs
 whatever was specified, sending all output to syslog.
+
+**Note**: `cron-5-minute-helper` is currently on the `dev` branch of `oref0`. To
+install:
+```
+sudo npm install -g git://github.com/openaps/oref0.git#dev
+```
+Be aware that switching to the dev version of `oref0` will potentially include
+other changes still in active development. You'll want to revert to the latest
+release before using other `oref0` features:
+```
+sudo npm install -g git://github.com/openaps/oref0.git
+```


### PR DESCRIPTION
I couldn't find `cron-5-minute-helper` in my `oref0` install so I added a note for enabling it. (Not sure how wise it is to direct people to installing the dev branch, happy to re-word as you see fit. It might also just make more sense to merge the feature and cut a new release.)