### PR TITLE
Added note about meal device

### DIFF
--- a/docs/docs/walkthrough/phase-6/Configure-Automatic-Sensitivity-Mode-and-Advanced-Meal-Assist.md
+++ b/docs/docs/walkthrough/phase-6/Configure-Automatic-Sensitivity-Mode-and-Advanced-Meal-Assist.md
@@ -197,6 +197,7 @@ fields = pumphistory profile clock glucose basal carbs
 cmd = oref0
 args = meal
 
+* Only include carbs if you are getting this from Nightscout. If you enter carbs into your pump via the Bolus wizard, you can ignore add this to fields.
 ```
 
 3) We need to update our aliases to actually call these new reports.


### PR DESCRIPTION
Added clarification that if you are getting carbs from pump directly, you do not need to call it from Nightscout.