### PR TITLE
Add readme content to index starting page for RTD

### DIFF
--- a/docs/docs/introduction/understand-this-guide.md
+++ b/docs/docs/introduction/understand-this-guide.md
@@ -18,7 +18,7 @@ One helpful thing to do before starting any software work is to log your termina
 
 You won't see a full loop where you can just download the code, press a button, and have a live loop. There are many places where there are examples, and instructions, but you must do the work to understand how to communicate between devices and transfer data between reports and files. This is key for helping you understand what you are building and how it will work.
 
-In some cases, the documentation needs to be built out further, with easier to understand language and more examples. However, there are a few things (like a full `cron` example) that are not included in this guide, and intentionally so in order to ensure that you have full intent and autonomy in building your system for yourself.
+In some cases, the documentation needs to be built out further, with easier to understand language and more examples. You should have full intent and autonomy in building your system for yourself.
 
 ### But wait - I need the "Dummy" version
 
@@ -26,4 +26,4 @@ Well, actually, you don't.  If you can deal with diabetes, invoking shell script
 
 It may help to think of the OpenAPS setup as a tiny "diabetes brain" which is focused only on figuring out how much basal insulin you should be getting.  It does this by collecting all that background data we usually let our pumps deal with: what is your insulin sensitivity, your target BG, the duration of action for insulin, etc.  Then, it collects more immediate data, such as what is the current IOB, and basal rate, as well as checking out the CGM to see what your BG has been up to recently.  Then, it decides what should be changed (if anything) and tells your pump to go to a new temp basal rate, either higher or lower, depending on all the other factors.
 
-As you go through the steps to run the manual loop, the longer-term data is collected in the "settings" directory, with file names indicating what sort of data they contain.  The data representing what is going on right now is in the "monitor" directory, and the recommendation for what should change goes in the "enact" directory.  To close the loop, you add a "cron" script, which just directs the computer to do something at a certain time interval.  You will need to be very certain all your manual pieces are running correctly before you decide to close the loop, which is why the "cron" section does not contain any examples.
+As you go through the steps to run the loop, the longer-term data is collected in the "settings" directory, with file names indicating what sort of data they contain.  The data representing what is going on right now is in the "monitor" directory, and the recommendation for what should change goes in the "enact" directory.  To close the loop, you will have added a "cron" script, which just directs the computer to do something at a certain time interval.  

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,36 @@
 Welcome to OpenAPS's documentation!
 ==============================================
 
+This documentation support a self-driven Do-It-Yourself (DIY) implementation of an artificial pancreas based on the OpenAPS reference design. By proceeding to use these tools or any piece within, you agree to the copyright (see LICENSE.txt for more information) and release any contributors from liability, and assume full responsibility for all of your actions and outcomes related to usage of these tools or ideas.
+
+*A Note on DIY and the "Open" Part of OpenAPS*
+
+This is a set of development tools to support a self-driven DIY implementation. Any person choosing to use these tools is solely responsible for testing and implementing these tools independently or together as a system.
+
+The DIY part of OpenAPS is important. While formal training or experience as an engineer or a developer is not a prerequisite, a growth mindset is required to learn to work with the "building blocks" that will help you develop your OpenAPS instance. Remember as you consider this project that this is not a "set and forget" system; an OpenAPS implementation requires diligent and consistent testing and monitoring to ensure each piece of the system is monitoring, predicting, and controlling as desired. The performance and quality of your system lies solely with you.
+
+This community of contributors believes in "paying it forward," and individuals who are implementing these tools are asked to contribute by asking questions, helping improve documentation, and contributing in other ways.
+OpenAPS System Development Phases
+
+This documentation is organized into a series of phases that progressively build upon the openaps development tools towards a working OpenAPS system. The phases are as follows:
+
+    Phase 0: General Setup
+    Get the equipment you need; record baseline data, configure your hardware, install software, and become familiar with the openaps environment.
+
+    Phase 1: Monitoring and Visualization Setup
+    Prepare Nightscout or other visualization tools that are key for monitoring a closed loop.
+
+    Phase 2: Creating a a PLGM or open loop
+    Use the setup script to build a basic loop; you can choose to run the loop manually ("open loop" mode), or automate your loop. At this stage, you should review and refine algorithms, test different scenarios for safety, etc.
+
+    Phase 3: Understanding Your Loop and Tweaking Settings
+    Analyze the basal recommendations that are outputted from your system; run in a test environment for multiple days to configure safety settings that are right for you before moving forward.
+
+    Phase 4: Iterate and Improve the Closed Loop
+    At the end of the previous stages and after 3 consecutive nights with no hardware failures and at least 1 night without low alarms, you can move into advanced features like meal-assist and auto-sensitivity tuning. Also improve the functionality of the system with additional software or hardware development
+
+
+
 .. toctree::
    :maxdepth: 3
    :glob:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Welcome to OpenAPS's documentation!
 ==============================================
 
-This documentation support a self-driven Do-It-Yourself (DIY) implementation of an artificial pancreas based on the OpenAPS reference design. By proceeding to use these tools or any piece within, you agree to the copyright (see LICENSE.txt for more information; or [the full README here](https://github.com/openaps/docs/blob/master/README.md)) and release any contributors from liability, and assume full responsibility for all of your actions and outcomes related to usage of these tools or ideas.
+This documentation support a self-driven Do-It-Yourself (DIY) implementation of an artificial pancreas based on the OpenAPS reference design. By proceeding to use these tools or any piece within, you agree to the copyright (see LICENSE.txt for more information; and the full README here: https://github.com/openaps/docs/blob/master/README.md ) and release any contributors from liability, and assume full responsibility for all of your actions and outcomes related to usage of these tools or ideas.
 
 *A Note on DIY and the "Open" Part of OpenAPS*
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Welcome to OpenAPS's documentation!
 ==============================================
 
-This documentation support a self-driven Do-It-Yourself (DIY) implementation of an artificial pancreas based on the OpenAPS reference design. By proceeding to use these tools or any piece within, you agree to the copyright (see LICENSE.txt for more information) and release any contributors from liability, and assume full responsibility for all of your actions and outcomes related to usage of these tools or ideas.
+This documentation support a self-driven Do-It-Yourself (DIY) implementation of an artificial pancreas based on the OpenAPS reference design. By proceeding to use these tools or any piece within, you agree to the copyright (see LICENSE.txt for more information; or [the full README here](https://github.com/openaps/docs/blob/master/README.md)) and release any contributors from liability, and assume full responsibility for all of your actions and outcomes related to usage of these tools or ideas.
 
 *A Note on DIY and the "Open" Part of OpenAPS*
 
@@ -10,24 +10,6 @@ This is a set of development tools to support a self-driven DIY implementation. 
 The DIY part of OpenAPS is important. While formal training or experience as an engineer or a developer is not a prerequisite, a growth mindset is required to learn to work with the "building blocks" that will help you develop your OpenAPS instance. Remember as you consider this project that this is not a "set and forget" system; an OpenAPS implementation requires diligent and consistent testing and monitoring to ensure each piece of the system is monitoring, predicting, and controlling as desired. The performance and quality of your system lies solely with you.
 
 This community of contributors believes in "paying it forward," and individuals who are implementing these tools are asked to contribute by asking questions, helping improve documentation, and contributing in other ways.
-OpenAPS System Development Phases
-
-This documentation is organized into a series of phases that progressively build upon the openaps development tools towards a working OpenAPS system. The phases are as follows:
-
-    Phase 0: General Setup
-    Get the equipment you need; record baseline data, configure your hardware, install software, and become familiar with the openaps environment.
-
-    Phase 1: Monitoring and Visualization Setup
-    Prepare Nightscout or other visualization tools that are key for monitoring a closed loop.
-
-    Phase 2: Creating a a PLGM or open loop
-    Use the setup script to build a basic loop; you can choose to run the loop manually ("open loop" mode), or automate your loop. At this stage, you should review and refine algorithms, test different scenarios for safety, etc.
-
-    Phase 3: Understanding Your Loop and Tweaking Settings
-    Analyze the basal recommendations that are outputted from your system; run in a test environment for multiple days to configure safety settings that are right for you before moving forward.
-
-    Phase 4: Iterate and Improve the Closed Loop
-    At the end of the previous stages and after 3 consecutive nights with no hardware failures and at least 1 night without low alarms, you can move into advanced features like meal-assist and auto-sensitivity tuning. Also improve the functionality of the system with additional software or hardware development
 
 
 


### PR DESCRIPTION
Adding key content from README (which no one sees if they go straight to ReadTheDocs views). Also tweaked understanding this guide to reflect new reality of setup scripts vs. old cron gaps in docs.