### PR TITLE
Update Running Autotune in “manual” mode

### DIFF
--- a/docs/docs/walkthrough/phase-4/autotune.md
+++ b/docs/docs/walkthrough/phase-4/autotune.md
@@ -40,8 +40,8 @@ Autotune is currently being tested by a few users on the command line. There has
 How to run it as a one-off:
 * First, make sure you have the latest version of oref0: `npm list -g oref0 | egrep oref0@0.4.[0-9] || (echo Installing latest oref0 package && sudo npm install -g oref0)`
 * Install jq: `sudo apt-get install jq`
-* Run `oref0-autotune --dir=~/myopenaps --ns-host=https://mynightscout.azurewebsites.net --start-date=YYYY-MM-DD` (obviously, sub in your NS url and the start date you want to start with. Try 1 day first before moving on to 1 week and 1 month to better troubleshoot).
 * Make two copies of your profile.json, one to be the starting point for autotune, and one to provide the pump baseline for enforcing the 20-30% min/max limits: `cd ~/myopenaps/settings/ && cp profile.json autotune.json && cp profile.json pumpprofile.json`
+* Run `oref0-autotune --dir=~/myopenaps --ns-host=https://mynightscout.azurewebsites.net --start-date=YYYY-MM-DD` (obviously, sub in your NS url and the start date you want to start with. Try 1 day first before moving on to 1 week and 1 month to better troubleshoot).
 
 If you have issues running it, questions about reviewing the data, or want to provide input for direction of the feature, please comment on [this issue in Github](https://github.com/openaps/oref0/issues/261).
 


### PR DESCRIPTION
Updating the order of steps. The copies of the profile.json file need to be there before running autotune. Otherwise you get an error. These files are not created automatically when running the setup script if you do not select autotune as one of the advanced features to install. Once the file is copied, autotune runs without any problems