### PR TITLE
Update on-the-go-wifi-adding.md - App Name Change

### DIFF
--- a/docs/docs/walkthrough/phase-2/on-the-go-wifi-adding.md
+++ b/docs/docs/walkthrough/phase-2/on-the-go-wifi-adding.md
@@ -13,7 +13,7 @@ Since OpenAPS rig needs internet connection, most of the times we would prefer t
 
 On the iPhone, download these two apps:
 
-* Terminus – SSH Shell/Console/Terminal 
+* Termius – SSH Shell/Console/Terminal 
 * iNet
 
 ![Example of apps](../../Images/Example_iphone_apps.png)
@@ -60,7 +60,7 @@ We are all done with the iNet app.
 
 ## 4. Set up a connection to the rig on the iPhone
 
-Now we are moving over to the Terminus app.  When you first open the app, it will prompt you to add a new host.  Go ahead and click the button to add a new host.  You are going to fill out the following lines:
+Now we are moving over to the Termius app.  When you first open the app, it will prompt you to add a new host.  Go ahead and click the button to add a new host.  You are going to fill out the following lines:
 ```
 Alias – pick a name that let’s you know this is the rig when it’s hotspotted with your iPhone
 


### PR DESCRIPTION
Changed the name of the iPhone app to "Termius" instead of "Terminus". When I was going through the instructions I first searched for Terminus but couldn't find it. When I searched for SSH Client I found the Termius app and I assume that's what this doc is referring to. Thanks!