### PR TITLE
Update setup-edison.md

### DIFF
--- a/docs/docs/walkthrough/phase-0/setup-edison.md
+++ b/docs/docs/walkthrough/phase-0/setup-edison.md
@@ -236,7 +236,7 @@ in something closer to 10 seconds than 10 minutes, then you likely didn't set up
 
 c) If you have a failed flash or have problems with the reboot, try starting the console and hitting enter a bunch of times while connecting to stop autoboot.  You'll then be at a `boot>` prompt.  Run `sudo ./flashall.sh` and when it asks you to reboot type and enter `run do_flash` at the `boot>` prompt.
 
-d) If you get an error that says "Ready to receive application" on the Edison the problem is you don't have enough power to properly boot up the Edison. This can happen if you are powering from your Pi. You should either connect a battery to the Edison board to give it a little boost, or use a powered USB hub between the Pi and the Edison.
+d) If you get stuck on an error that says "Ready to receive application" on the Edison the problem is you don't have enough power to properly boot up the Edison. This can happen if you are powering from your Pi. You should either connect a battery to the Edison board to give it a little boost, or use a powered USB hub between the Pi and the Edison.
 
 e) If Edison reboots correctly but never gets picked up by the flashall.sh script and the flashing process does not start, check the Edison device ID. It will probably come out automatically after the flashall.sh script fails with a list of available devices connected to the machine. On Linux, you can run lsusb to get a list of usb devices with their device ID. If the device ID is different from the one expected on flashall.sh, you can edit the script and change lines containing: USB_VID=8087 & USB_PID=0a99 to whatever the Edison has for an ID. Some users have encountered their devices ID to be 8087:0a9e
 


### PR DESCRIPTION
Setting up my Edison, I kept booting to Rescue mode.  Eventually it all started working (not really sure how or why).  But along the way I was really confused by error messages in the logs.  Scott eventually reassured me that many of these are not a cause for concern.  He directed to me to re-read the troubleshooting docs.  One tip said "If you see Ready to receive application" you don't have enough power.  Scott clarified that this should really read:  "If you get stuck on Ready to receive application".  I have made my first Pull Request to update the docs to clarify this!