### PR TITLE
Update jubilinux URL and file download URL

### DIFF
--- a/docs/docs/walkthrough/phase-0/setup-edison.md
+++ b/docs/docs/walkthrough/phase-0/setup-edison.md
@@ -45,9 +45,9 @@ Windows PCs with less than 6 GB of RAM  may need to have the size of the page fi
 ## Downloading image
 
 ### Jubilinux
-[Jubilinux](http://www.robinkirkman.com/jubilinux/) "is an update to the stock ubilinux edison distribution to make it more useful as a server, most significantly by upgrading from wheezy to jessie."  That means we can skip many of the time-consuming upgrade steps below that are required when starting from ubilinux.
+[Jubilinux](http://www.jubilinux.org/) "is an update to the stock ubilinux edison distribution to make it more useful as a server, most significantly by upgrading from wheezy to jessie."  That means we can skip many of the time-consuming upgrade steps below that are required when starting from ubilinux.
 
-  - Download [jubilinux.zip](http://www.robinkirkman.com/jubilinux/jubilinux.zip)
+  - Download the latest [jubilinux.zip](http://www.jubilinux.org/dist/)
   - In download folder, right-click on file and extract (or use `unzip jubilinux.zip` from the command line) You will access this directory from a command prompt in the next step. It is a good idea to create the Jubilinux in your root directory to make this easier to access.
   - Open a terminal window and navigate to the extracted folder: `cd jubilinux`. If using Windows OS use the command prompt (cmd). This is your "flash window", keep it open for later.
   


### PR DESCRIPTION
Jubilinux is no longer hosted on www.robinkirkman.com and while the old download link may still work, it would probably be best to point people to the new site and the new downloads directory rather than a direct link to a specific version.