### PR TITLE
Update oref0-setup.md

### DIFF
--- a/docs/docs/walkthrough/phase-2/oref0-setup.md
+++ b/docs/docs/walkthrough/phase-2/oref0-setup.md
@@ -48,7 +48,7 @@ If you have been looping for awhile, are setting up an additional rig, are comfo
 
 `mkdir -p ~/src; cd ~/src && git clone -b dev git://github.com/openaps/oref0.git || (cd oref0 && git checkout dev && git pull)`
 
-`npm run global-install`
+`npm run global-install` (note this is only necessary for the dev branch, NOT for master)
 
 ## Step 2: Run oref0-setup
 


### PR DESCRIPTION
added a caveat that `npm run global-install` is only required for the dev branch, not for master