### PR TITLE
Adding warning about pump basal settings of zero

### DIFF
--- a/docs/docs/walkthrough/phase-3/Understand-determine-basal.md
+++ b/docs/docs/walkthrough/phase-3/Understand-determine-basal.md
@@ -95,7 +95,7 @@ For each different situation, the determine-basal output will be slightly differ
 
 If after reading through the code you are still unclear as to why determine-basal made a given decision (or think it may be the wrong decision for the situation), please join the #intend-to-bolus channel on Gitter, paste your output and any other context, and we'll be happy to discuss with you what it was doing and why, and whether that's the best thing to do in that and similar situations.
 
-## Note about Square Boluses, Dual Wave Boluses and Basal Pump Settings of Zero
+## Note about Square Boluses, Dual Wave Boluses, and Basal Pump Settings of Zero
 
 Due to the way the Medtronic Pumps operate, it should be known that temp basals can only be set when there is no bolus running, including extended (square) / dual wave boluses.  
 

--- a/docs/docs/walkthrough/phase-3/Understand-determine-basal.md
+++ b/docs/docs/walkthrough/phase-3/Understand-determine-basal.md
@@ -95,8 +95,10 @@ For each different situation, the determine-basal output will be slightly differ
 
 If after reading through the code you are still unclear as to why determine-basal made a given decision (or think it may be the wrong decision for the situation), please join the #intend-to-bolus channel on Gitter, paste your output and any other context, and we'll be happy to discuss with you what it was doing and why, and whether that's the best thing to do in that and similar situations.
 
-## Note about Square Boluses and Dual Wave Boluses
+## Note about Square Boluses, Dual Wave Boluses and Basal Pump Settings of Zero
 
 Due to the way the Medtronic Pumps operate, it should be known that temp basals can only be set when there is no bolus running, including extended (square) / dual wave boluses.  
 
 Thus it should be noted that if you use an extended bolus for carb heavy meals (e.g. Pizza), which may still be the optimal approach for you, OpenAPS will not be able to provide temp basals during the extended bolus.
+
+If you have periods in the day where your pump normally has basal settings of zero - your loop will not work!  You can resolve this by setting the lowest possible basal setting your pump will permit.  OpenAPS will then issue temp basals of zero, as needed.


### PR DESCRIPTION
Adding warning that pump basal settings of zero will prevent OpenAPS from working properly.