### PR TITLE
Update Reference Design Link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the [openaps](https://github.com/openaps/) documentation!
 
-This documentation supports implementing a self driven, Do It Yourself (DIY) artificial pancreas, based on the [OpenAPS Reference Design](http://openaps.org/open-artificial-pancreas-system-openaps-reference-design/). By proceeding to use these tools or any [openaps](https://github.com/openaps/) repositories, you agree to abide by the copyright agreement and release any contributors from any liability. You assume full responsibility for all actions and outcomes related to use of these tools or ideas. [Please read the copyright agreement before proceeding](https://github.com/openaps/docs/blob/master/license.txt).
+This documentation supports implementing a self driven, Do It Yourself (DIY) artificial pancreas, based on the [OpenAPS Reference Design](https://openaps.org/reference-design/). By proceeding to use these tools or any [openaps](https://github.com/openaps/) repositories, you agree to abide by the copyright agreement and release any contributors from any liability. You assume full responsibility for all actions and outcomes related to use of these tools or ideas. [Please read the copyright agreement before proceeding](https://github.com/openaps/docs/blob/master/license.txt).
 
 * [The easiest option for reading the documentation is by using this version](https://openaps.readthedocs.org/en/latest/index.html). (You may want to bookmark this link.)
 


### PR DESCRIPTION
Link to reference design page from README.md took me to a 404, updated the link to reflect the correct reference design link from openaps.org