### PR TITLE
Importance of knowing basics of insulin pump

### DIFF
--- a/docs/docs/walkthrough/phase-0/hardware/pump.md
+++ b/docs/docs/walkthrough/phase-0/hardware/pump.md
@@ -1,7 +1,5 @@
 # Information about compatible insulin pumps
 
-NOTE: If you are considering moving from Multiple Daily Injections (MDI) to an insulin pump,, it is important that you have  VERY detailed knowledge about the way a pump works. Insulin pumps use both basal and bolus settings for dosing and only use fast acting insulin. If you just purchased a compatible pump you are probably eager to start closing the loop. OpenAPS uses the settings and information that is manually set by the user (usually with help from their Healthcare Provider) into the pump to make dosing recommendations. First things first: understand how to safely use your pump before proceeding.
-
 !["Can I do OpenAPS with this pump?"](../Can_I_close_the_loop_with_this_pump_May_20_2016.jpg "Can I do OpenAPS with this pump?")
 
 Currently, only the following Medtronic MiniMed models allow us to remotely set temporary basal rate commands, which is required to do OpenAPS:
@@ -42,6 +40,10 @@ pumps lying around in their closets gathering dust. [MedWow](http://www.medwow.c
 Note: If you're buying a pump online, we recommend you ask the seller to confirm the
 firmware version of the pump. (You may also want to consider asking for a video
 of the pump with working functionality before purchasing.)
+
+## Make sure you understand your pump basics
+
+If you are considering moving from Multiple Daily Injections (MDI) to an insulin pump - or changing brands/types of pumps - it is important that you have VERY detailed knowledge about the way a pump works. Insulin pumps use both basal and bolus settings for dosing and only use fast acting insulin. If you just purchased a compatible pump you are probably eager to start closing the loop. OpenAPS uses the settings and information that is manually set by the user (usually with help from their Healthcare Provider) into the pump to make dosing adjustments. First things first: make sure you understand how to safely use your pump in "manual mode" before proceeding.
 
 ## Battery usage
 

--- a/docs/docs/walkthrough/phase-0/hardware/pump.md
+++ b/docs/docs/walkthrough/phase-0/hardware/pump.md
@@ -1,5 +1,7 @@
 # Information about compatible insulin pumps
 
+NOTE: If you are considering moving from Multiple Daily Injections (MDI) to an insulin pump,, it is important that you have  VERY detailed knowledge about the way a pump works. Insulin pumps use both basal and bolus settings for dosing and only use fast acting insulin. If you just purchased a compatible pump you are probably eager to start closing the loop. OpenAPS uses the settings and information that is manually set by the user (usually with help from their Healthcare Provider) into the pump to make dosing recommendations. First things first: understand how to safely use your pump before proceeding.
+
 !["Can I do OpenAPS with this pump?"](../Can_I_close_the_loop_with_this_pump_May_20_2016.jpg "Can I do OpenAPS with this pump?")
 
 Currently, only the following Medtronic MiniMed models allow us to remotely set temporary basal rate commands, which is required to do OpenAPS:


### PR DESCRIPTION
This section should have information that cautions users that starting on a closed loop without foundational knowledge about insulin pumps could be hazardous.

"NOTE: If you are considering moving from Multiple Daily Injections (MDI) to an insulin pump, it is important that you have  VERY detailed knowledge about the way a pump works. Insulin pumps use both basal and bolus settings for dosing and only use fast acting insulin. If you just purchased a compatible pump you are probably eager to start closing the loop. OpenAPS uses the settings and information that is manually set by the user (usually with help from their Healthcare Provider) into the pump to make dosing recommendations. First things first: understand how to safely use your pump before proceeding."