### PR TITLE
Added NS config for data backfills

### DIFF
--- a/docs/docs/walkthrough/phase-1/nightscout-setup.md
+++ b/docs/docs/walkthrough/phase-1/nightscout-setup.md
@@ -113,10 +113,20 @@ your data, customized watchfaces with your OpenAPS data, and integration with IF
 <th>BRIDGE_PASSWORD</th>
 <td>Enter your Dexcom Share Account password.</td>
 </tr>
+<tr>
+<th>BRIDGE_MAX_COUNT</th>
+<td>Default value is 1.  Setting this to 7 will update the last 35 minutes of data.</td>
+</tr>
 </tbody>
 </table>
 
 **The remaining variables can be left at their default values.**</br></br>
+
+*****************
+**Note:** for BRIDGE_MAX_COUNT: This value sets the number of BG values to pull from Share per update.  Each Dexcom BG value represent 5 minutes.  Nightscount defaults to BRIDGE_MAX_COUNT=1.  If you lose connectivity with your Dexcom transmitter, your Share app will automatically backfill data points when you regain connectivity.  Nightscount does not do this and you will have gaps in the data for when you were out of range.  More information here https://github.com/nightscout/cgm-remote-monitor#bridge-share2nightscout-bridge  
+
+You can change the BRIDGE_MAX_COUNT value to pull more samples per query, which will backfill BRIDGE_MAX_COUNT values for you.  This change increases your data usage and may affect your Nightscout billing tier.   Setting BRIDGE_MAX_COUNT to 7 will update the previous 35 minutes of data and will keep OpenAPS up to date on your current BG trends.  If you frequently have larger data gaps and you use autotune, you may consider increasing this number more to backfill data more aggressively.
+*****************
 
 * Click the purple `Deploy` button at the bottom of screen.
 


### PR DESCRIPTION
#851 

Proposed instructions on configuring NS to back fill missing data points from when the transmitter is out of range from Share uploader.