### PR TITLE
Interrupting kernel messages in console/screen mode

### DIFF
--- a/docs/docs/walkthrough/phase-0/setup-edison.md
+++ b/docs/docs/walkthrough/phase-0/setup-edison.md
@@ -380,7 +380,8 @@ Once that looks correct, save the file and `reboot` your rig for the changes to 
 
 
 ### Interrupting Kernel Messages in Console/Screen Mode
-https://user-images.githubusercontent.com/24418738/27111189-17c4acd8-5074-11e7-8873-54470e94c638.jpg
+
+![Example kernel message](https://user-images.githubusercontent.com/24418738/27111189-17c4acd8-5074-11e7-8873-54470e94c638.jpg)
 
 #### Fix for individual console/screen session:
 
@@ -393,7 +394,7 @@ press i for insert mode
 
 add this line:    sudo dmesg -n 1
 
-https://user-images.githubusercontent.com/24418738/27111188-17c46c3c-5074-11e7-8a5f-d29c85873293.jpg
+![adding dmesg](https://user-images.githubusercontent.com/24418738/27111188-17c46c3c-5074-11e7-8a5f-d29c85873293.jpg)
 
 (remember to save and exit the vi editor by using esc and then :wq)
 

--- a/docs/docs/walkthrough/phase-0/setup-edison.md
+++ b/docs/docs/walkthrough/phase-0/setup-edison.md
@@ -382,16 +382,18 @@ Once that looks correct, save the file and `reboot` your rig for the changes to 
 ### Interrupting Kernel Messages in Console/Screen Mode
 https://user-images.githubusercontent.com/24418738/27111189-17c4acd8-5074-11e7-8873-54470e94c638.jpg
 
-Fix for individual console/screen session:
-type this at the prompt:   dmesg -D
+#### Fix for individual console/screen session:
 
-Permanant solution:
+Type this at the prompt:   `dmesg -D`
 
-vi /etc/rc.local
+#### Permanant solution:
+
+`vi /etc/rc.local`
 press i for insert mode
-add this line:    sudo dmesg -n 1
-https://user-images.githubusercontent.com/24418738/27111188-17c46c3c-5074-11e7-8a5f-d29c85873293.jpg
 
+add this line:    sudo dmesg -n 1
+
+https://user-images.githubusercontent.com/24418738/27111188-17c46c3c-5074-11e7-8a5f-d29c85873293.jpg
 
 (remember to save and exit the vi editor by using esc and then :wq)
 

--- a/docs/docs/walkthrough/phase-0/setup-edison.md
+++ b/docs/docs/walkthrough/phase-0/setup-edison.md
@@ -377,3 +377,22 @@ iface wlan0 inet dhcp
 ```
 
 Once that looks correct, save the file and `reboot` your rig for the changes to take effect.
+
+
+### Interrupting Kernel Messages in Console/Screen Mode
+https://user-images.githubusercontent.com/24418738/27111189-17c4acd8-5074-11e7-8873-54470e94c638.jpg
+
+Fix for individual console/screen session:
+type this at the prompt:   dmesg -D
+
+Permanant solution:
+
+vi /etc/rc.local
+press i for insert mode
+add this line:    sudo dmesg -n 1
+https://user-images.githubusercontent.com/24418738/27111188-17c46c3c-5074-11e7-8a5f-d29c85873293.jpg
+
+
+(remember to save and exit the vi editor by using esc and then :wq)
+
+


### PR DESCRIPTION
How to fix the interrupting kernel messages in console/screen mode for OpenAPS (kernel messages are those lines that start with a set of bracketed numbers usually) These messages will continuously scroll on your screen as you are trying to work on your rig. 

(Thank you Katie DiSimone for creating this awesome solution to an aggravating issue.)

interrupting kernel messages
fix interrupting kernel messages