### PR TITLE
Remove the full path to the wifi.sh file

### DIFF
--- a/docs/docs/Resources/wifi.md
+++ b/docs/docs/Resources/wifi.md
@@ -7,7 +7,7 @@ There is a script that you can add to your root cron that will test your connect
 cd ~/src
 git clone https://github.com/TC2013/edison_wifi
 cd edison_wifi
-chmod 0755 /home/edison/src/edison_wifi/wifi.sh
+chmod 0755 wifi.sh
 ```
 Next, add the script to your root cron. Note this is a different cron that what your loops runs on, so when you open it don't expect to see your loop and other items you have added.
   * Log in as root ```su root```


### PR DESCRIPTION
Trying to chmod the file with the full pathname when I was in the directory caused an error. Removing the full path solved it.