### PR TITLE
Update bluetooth-tethering-edison.md

### DIFF
--- a/docs/docs/walkthrough/phase-4/bluetooth-tethering-edison.md
+++ b/docs/docs/walkthrough/phase-4/bluetooth-tethering-edison.md
@@ -157,7 +157,7 @@ Device AA:BB:CC:DD:EE:FF Samsung S7
 
 * If you get a `Can't change local name on hci0: Network is down (100)` error, start over with `killall` and wait longer between steps.
 
-* Make sure your phone's hotspot is enabled (but don't let anything connect via wifi).
+* Make sure your phone's hotspot is enabled, but don't let anything connect via wifi (you have to switch on the personal hotspot toggle, but then immediately back out of the personal hotspot screen before anything connects to your hotspot via wifi).
 
 * Now, try to establish a Bluetooth Network connection with your phone:
 


### PR DESCRIPTION
Dirk Gastaldo @dirkgastaldo 21:26
Hello. I'm in the BT tethering "testing to make sure it works" section, and this instruction, what does it mean don't let anything connect via wifi? "Make sure your phone’s hotspot is enabled (but don’t let anything connect via wifi)."

Scott Leibrand @scottleibrand 21:26
you have to switch on the personal hotspot toggle, but then immediately back out of the personal hotspot screen before anything connects to your hotspot via wifi

Dirk Gastaldo @dirkgastaldo 21:27
ok, thank you, giving that a try

Scott Leibrand @scottleibrand 21:28
Please PR in a clarification to that section of the docs once you get it working.