### PR TITLE
Note added to bootstrap script re spaces in network name

### DIFF
--- a/scripts/openaps-bootstrap.sh
+++ b/scripts/openaps-bootstrap.sh
@@ -8,6 +8,7 @@ wpa_cli scan_res | sort -grk 3 | head | awk -F '\t' '{print $NF}' | uniq
 set -e
 echo -e /"\nWARNING: this script will back up and remove all of your current wifi configs."
 read -p "Press Ctrl-C to cancel, or press Enter to continue:" -r
+echo -e "\nNOTE: Do not use quotes to preserve spaces in the network name and password you enter."
 read -p "Enter your network name: " -r
 SSID=$REPLY
 read -p "Enter your network password: " -r

--- a/scripts/openaps-bootstrap.sh
+++ b/scripts/openaps-bootstrap.sh
@@ -8,7 +8,7 @@ wpa_cli scan_res | sort -grk 3 | head | awk -F '\t' '{print $NF}' | uniq
 set -e
 echo -e /"\nWARNING: this script will back up and remove all of your current wifi configs."
 read -p "Press Ctrl-C to cancel, or press Enter to continue:" -r
-echo -e "\nNOTE: Do not use quotes to preserve spaces in the network name and password you enter."
+echo -e "\nNOTE: Spaces in your network name or password are ok. Do not add quotes."
 read -p "Enter your network name: " -r
 SSID=$REPLY
 read -p "Enter your network password: " -r


### PR DESCRIPTION
Added a note for the user to make sure they know that quotes aren't necessary to preserve spaces... Thought about adding code to remove quotes, etc, but that seemed more complex than just letting the user know not to use quotes.