### PR TITLE
Update communication-support-channels.md

### DIFF
--- a/docs/docs/Understanding OpenAPS-Overview/communication-support-channels.md
+++ b/docs/docs/Understanding OpenAPS-Overview/communication-support-channels.md
@@ -1,15 +1,18 @@
 # Where to go for help
 
-There are several ways to communicate with other participants and contributors in the #OpenAPS project. See also the [Resources](../Resources/index.rst) section for additional assistance.
+There are several ways to communicate with other participants and contributors in the OpenAPS project. See also the [Resources](../Resources/index.rst) section for additional assistance.
 
 **Note:** It's best practice not to share your pump's serial number, so make sure not to include it in pictures or pasted text output when seeking help on pump communication.
 
 **Related**: You may want to read [this blog post for tips on how to best seek help when troubleshooting online](https://diyps.org/2017/03/19/tips-for-troubleshooting-diy-diabetes-devices-openaps-or-otherwise/) - there is a lot of information you can provide proactively when seeking help that will aid in getting your issue resolved more quickly.
 
+### Read the docs
+You may see "rtd" when talking online with the OpenAPS community. This stands for "read the docs" and is a polite reminder to use the resources that already exist online. There is a wealth of information in the OpenAPS docs. There is a "Search docs" function in the upper-left corner of each page of the docs. If you encounter a problem it's possible that problem is discussed in the docs. Search for a key word, words, short phrase or a snippet of the error message.
+
 ### Gitter
 [Gitter](https://gitter.im/) is a messaging/chat service similar to IRC. It provides integration with GitHub and several other services. It's the best place to get real-time support with anything related to OpenAPS. (Here's [why we often recommend asking questions on Gitter](https://diyps.org/2016/08/17/why-you-should-post-questions-in-gitter/).)
 
-* The [nightscout/intend-to-bolus]( https://gitter.im/nightscout/intend-to-bolus) channel is where you will find active #OpenAPS discussions ranging from technical issues with openaps tools to control theory to general information. It is a great place to introduce yourself and get some help from those who are a few steps further down the road.
+* The [nightscout/intend-to-bolus]( https://gitter.im/nightscout/intend-to-bolus) channel is where you will find active OpenAPS discussions ranging from technical issues with OpenAPS tools to control theory to general information. It is a great place to introduce yourself and get some help from those who are a few steps further down the road.
 * For Autotune conversations, use the [openaps/autotune channel](https://gitter.im/openaps/autotune)
 * For TI stick communication, use the [oskarpearson/mmeowlink channel](https://gitter.im/oskarpearson/mmeowlink)
 * For RileyLink conversations, use the [ps2/rileylink channel](https://gitter.im/ps2/rileylink)
@@ -17,7 +20,7 @@ There are several ways to communicate with other participants and contributors i
 
 Gitter has a search function to find old information, but since it isn't threaded converations, you may need to spend some time reading the posts after the search result to find the ultimate resolution to the question.  So, if you find a particularly useful bit of information that you couldn't find in the docs...please make a PR to the docs so that the information is permanently stored for others to find.
 
-Tag someone! You can tag particular people if you are responding to them directly by using the `@` symbol and then typing their username.  This will help notify the person that you are "speaking to them".  If someone asks you for information that shouldn't be shared in the public channel, you can also private message people by hovering over their profile picture and choosing the "chat privately" button. Please do not abuse the tagging or PM features: most questions are best asked untagged in the appropriate channel, so that anyone can respond to them as soon as they read Gitter and see the question. There are people from all over the world online at all hours who can help with most kinds of questions, and the core developers usually read every message in Gitter a few times per day and try to answer any questions that got missed.
+Tag someone! You can tag particular people if you are responding to them directly by using the `@` symbol and then typing their username.  This will help notify the person that you are "speaking to them".  If someone asks you for information that shouldn't be shared in the public channel, you can also private message people by hovering over their profile picture and choosing the "chat privately" button. Please do not abuse the tagging or PM features: most questions are best asked untagged in the appropriate channel, so that anyone can respond to them as soon as they read Gitter and see the question. There are people from all over the world online at all hours who can help with most kinds of questions, and the core developers usually read messages in Gitter a few times per day and try to answer any questions that got missed.
 
 ![Gitter PM sample](../Images/gitter_pm.jpg)
 ************
@@ -28,17 +31,19 @@ Gitter has a mobile app which works great for posting text, but does not allow f
 Using the desktop application, you can simply drag and drop the file into the Gitter chat window.  The file will upload and then display in the chat thread after a short period of time to upload.
 *************
 
-Posting copy-paste code from your rig is also another valuable activity for troubleshooting.  To post a single line of information, you can use the single-backtick-quote that is found on the key to the left of the number 1 key on the keyboard.  (hint: it is under the ~ on the same key).  You can also long-press the single quote key on your iPhone keypad to bring up the single-backtick-quote that will work in Gitter.  If you start and stop a portion of your text with those single quotes, it will `look like this`.
+Posting copy-paste code from your rig is also another valuable activity for troubleshooting.  To post a single line of information, you can use the single-backtick-quote that is found on the key to the left of the number 1 key on the keyboard (hint: it is under the ~ on the same key).  You can also long-press the single quote key on your iPhone keypad to bring up the single-backtick-quote that will work in Gitter.  If you start and stop a portion of your text with those single quotes, it will `look like this`.
 
 Posting multiple lines of copy-paste from your rig will also sometimes be needed.  You can do that by:
 
-* start a single line of 3 single quotes (the same one we used in the example above)
+* start a single line of 3 single-backtick-quotes (the same one we used in the example above)
 * press `control-enter` to get a new line started
 * paste the lines of code that you want to post
 * press `control-enter` again to get another new line
-* enter 3 single quotes to end the section
+* enter 3 single-backtick-quotes to end the section
 
 The copy-pasted lines should have 3 backticks on the line above and the line below.  The example below shows, on the bottom, how the formatted text yielded the black box of text in Gitter.  Using this format helps troubleshooters read your information easier than unformatted copy and paste.
+
+For PC users, if `control-enter` doesn't work try `shift-enter`. `shift-enter` will enter two lines of 3 single-backtick-quotes within which you can paste your text. Press `control-enter` to enter your text.
 
 ![Gitter tickmarks](../Images/gitter_marks.jpg)
 
@@ -54,9 +59,9 @@ The Looped Group has grown considerably in the last 6 months and has many users 
 A google group focused on #OpenAPS development work can be found [here](https://groups.google.com/d/forum/openaps-dev). Request access to participate and see some of the archived discussions. If you're new, make sure to introduce yourself!
 
 ### Issues on openaps GitHub
-For reporting issues on the openaps tools formally, the openaps [issues page](https://github.com/openaps/openaps/issues) on GitHub is the proper forum. Feel free to try and get through the issues by working with others on the Gitter channel first if you think it may be something unrelated to the codebase.
+For reporting issues on the OpenAPS tools formally, the OpenAPS [issues page](https://github.com/openaps/openaps/issues) on GitHub is the proper forum. Feel free to try and get through the issues by working with others on the Gitter channel first if you think it may be something unrelated to the codebase.
 
 ### Other online forums
-Those in the #OpenAPS community are frequently found in other forums, such as on Twitter (using [the #OpenAPS hashtag](https://twitter.com/search?f=tweets&vertical=default&q=%23OpenAPS&src=typd), as well as [#WeAreNotWaiting](https://twitter.com/search?f=tweets&vertical=default&q=%23WeAreNotWaiting&src=typd)) and on Facebook in the ["CGM In The Cloud"](https://www.facebook.com/groups/cgminthecloud/) and ["Looped"](https://www.facebook.com/groups/TheLoopedGroup/)group.
+Those in the #OpenAPS community are frequently found in other forums, such as on Twitter (using [the #OpenAPS hashtag](https://twitter.com/search?f=tweets&vertical=default&q=%23OpenAPS&src=typd), as well as [#WeAreNotWaiting](https://twitter.com/search?f=tweets&vertical=default&q=%23WeAreNotWaiting&src=typd)) and on Facebook in the ["CGM In The Cloud"](https://www.facebook.com/groups/cgminthecloud/) group.
 
 There is also a [Slack channel](https://omniapsslack.azurewebsites.net/) to discuss communication around other pumps that are being explored for being used for other DIY closed loops.


### PR DESCRIPTION
excess "#"s in front of OpenAPS. If this is a style, disregard my change. I apologize, I see #OpenAPS in other locations. I guess it's being used to tag something, though I'm not familiar.
added a "rtd" paragraph
conform "openaps" to "OpenAPS"
3 single-backtick-quotes for PC users (at least for me)
Removed "Looped" group reference at end because it's got its own section immediately above this
nits