### PR TITLE
Adding link for HTTP Widget instructions

### DIFF
--- a/docs/docs/While You Wait For Gear/monitoring-OpenAPS.md
+++ b/docs/docs/While You Wait For Gear/monitoring-OpenAPS.md
@@ -512,5 +512,6 @@ C. Accessing via your phone
 **IPHONE USERS:** To access this from an iphone browser, enter something like the following: http://172.20.10.x:1337/index.html and you should receive an unformatted html page with the data in it. The value you need will be the ip address you see when you first set up bluetooth on your rig, and can be found using `ifconfig bnep0` when your rig is connected to your phone via bluetooth.  If you want to improve the output for a browser, the script can be modified to generate html tags that will allow formatting and could provide colouring if various predicted numbers were looking too low.
 
 **ANDROID USERS:** On Android, you can download http-widget (https://play.google.com/store/apps/details?id=net.rosoftlab.httpwidget1&hl=en_GB) and add a widget to your home screen that will display this data. You will need the IP address that your rig uses. If you are using xdrip as your glucose data source, it is the same as the value you use there.
+For more detailed instructions, see https://github.com/ceben80/http-widget?fref=gc&dti=1782449781971680.
 
 **SAMSUNG GEAR S3 WATCH USERS:** If you use a Samsung Gear S3 watch, you can use the above http-widget with Wearable Widgets (http://wearablewidgets.com) to view what OpenAPS is doing locally, without internet connection.


### PR DESCRIPTION
I found this github link that I think used to be in the docs but has disappeared. I'm adding it back into the section on how to get the HTTP Widget app to work for Android offline webpage monitoring.