### PR TITLE
Fix for API_SECRET VM error

### DIFF
--- a/docs/docs/Customize-Iterate/autotune.md
+++ b/docs/docs/Customize-Iterate/autotune.md
@@ -177,7 +177,7 @@ Every comma, quote mark, and bracket matter on this file, so please double-check
 If you get the error `ERROR: API_SECRET is not set when calling oref0-autotune.sh` try this:
 
 1. Log into your VM
-2. At the command promot, type `cd \etc` and hit enter
+2. At the command promot, type `cd /etc/` and hit enter
 2. Type `sudo nano environment` and hit enter
 3. You are now editing the `environment` file.  Add a new line to the file that says:  `API_SECRET=yourAPIsecret` (Note - replace "yourAPIsecret" with your own)
 4. Hit cntl O and enter to save the changes to the file

--- a/docs/docs/Customize-Iterate/autotune.md
+++ b/docs/docs/Customize-Iterate/autotune.md
@@ -180,8 +180,8 @@ If you get the error `ERROR: API_SECRET is not set when calling oref0-autotune.s
 2. At the command promot, type `cd /etc/` and hit enter
 2. Type `sudo nano environment` and hit enter
 3. You are now editing the `environment` file.  Add a new line to the file that says:  `API_SECRET=yourAPIsecret` (Note - replace "yourAPIsecret" with your own)
-4. Hit cntl O and enter to save the changes to the file
-5. Hit cntl X and enter to exit the file and go back to the command prompt
+4. Hit CTRL-O and enter to save the changes to the file
+5. Hit CTRL-X and enter to exit the file and go back to the command prompt
 6. At the command prompt, type `export API_SECRET=yourAPIsecret`  (Note - replace "yourAPIsecret" with your own)
 
 To test this fix, type `echo $API_SECRET` and hit enter.  If this returns the API Secret that you set in the `environment` file, then it should work for you to run autotune.

--- a/docs/docs/Customize-Iterate/autotune.md
+++ b/docs/docs/Customize-Iterate/autotune.md
@@ -174,6 +174,20 @@ Every comma, quote mark, and bracket matter on this file, so please double-check
 
 (First - breathe, and have patience! Remember this is a brand new tool that's in EARLY testing phases. Thanks for being an early tester...but don't panic if it doesn't work on your first try.) Here are some things to check: 
 
+If you get the error `ERROR: API_SECRET is not set when calling oref0-autotune.sh` try this:
+
+1. Log into your VM
+2. At the command promot, type `cd \etc` and hit enter
+2. Type `sudo nano environment` and hit enter
+3. You are now editing the `environment` file.  Add a new line to the file that says:  `API_SECRET=yourAPIsecret` (Note - replace "yourAPIsecret" with your own)
+4. Hit cntl O and enter to save the changes to the file
+5. Hit cntl X and enter to exit the file and go back to the command prompt
+6. At the command prompt, type `export API_SECRET=yourAPIsecret`  (Note - replace "yourAPIsecret" with your own)
+
+To test this fix, type `echo $API_SECRET` and hit enter.  If this returns the API Secret that you set in the `environment` file, then it should work for you to run autotune.
+
+Other things to check:
+
 * Does your Nightscout have data? It definitely needs BG data, but you may also get odd results if you do not have treatment (carb, bolus) data logged. See [this page](./understanding-autotune.md) with what output you should get and pay attention to depending on data input.
 * Did you pull too much data? Start with one day, and make sure it's a day where you had data in Nightscout. Work your way up to 1 week or 1 month of data. If you run into errors on a longer data pull, there may be something funky in Nightscout that's messing up the data format file and you'll want to exclude that date by picking a batch that does not include that particular date.
 * Make sure when you sub in your Nightscout URL you do not include a "/" at the end of the URL


### PR DESCRIPTION
Describes a fix for the following error when running autotune from a VM:  `ERROR: API_SECRET is not set when calling oref0-autotune.sh`