### PR TITLE
Added additional check for autotune profile.json fomat

### DIFF
--- a/docs/docs/Customize-Iterate/autotune.md
+++ b/docs/docs/Customize-Iterate/autotune.md
@@ -200,6 +200,20 @@ Other things to check:
 * Did you pull too much data? Start with one day, and make sure it's a day where you had data in Nightscout. Work your way up to 1 week or 1 month of data. If you run into errors on a longer data pull, there may be something funky in Nightscout that's messing up the data format file and you'll want to exclude that date by picking a batch that does not include that particular date.
 * Make sure when you sub in your Nightscout URL you do not include a "/" at the end of the URL
 * Check your profile.json and make sure it really matches the example - chances are there's a stray character in there.
+     - "start" time stamps must have the format "HH:MM:SS". "HH:MM" (e.g. "00:00" instead of "00:00:00") gives erroneous calculations such as "-Infinity" or "Nan" for the ISF and CR avlues. This results in the ISF & Carb ratio values being unchanged.
+       Example output (console):
+        ```oldCR: 9 fullNewCR: NaN newCR: NaN
+        p50deviation: -0.76 p50BGI 0 p50ratios: -Infinity Old ISF: 44 fullNewISF: -Infinity adjustedISF: 44 newISF: 44
+        ```
+        
+        Telltale sign is the input and output values for ISF and carb ratio remain unchanged:
+        ```Parameter      | Pump     | Autotune 
+           -------------------------------------
+           ISF [mg/dL/U]  | 44.000   | 44.000   
+           Carb Ratio[g/U]| 9.000    | 9.000    
+           Basals [U/hr]  | -        |       
+           ```
+     
 * Also check your pumpprofile.json and autotune.json - if it worked once or twice but then stopped working, it may have a bad file copy. If needed, follow Steps 3-E and 3-F again to re-copy a good profile.json to pumpprofile.json and autotune.json again.
 * If VM is already set up, and you are returning to your VM for another session of autotune, double-check that your VM timezone matches your pump: `sudo dpkg-reconfigure tzdata` 
 * Invalid calculations may be due to the locale settings of your VM (correct settings are `en_US.utf-8` or another locale that uses `.` as the decimal separator). An easy way to overcome such a problem is to add `env LANG=en_US.UTF-8` in front of your command for running autotune, it should look like this: `env LANG=en_US.UTF-8 oref0-autotune --dir=~/myopenaps --ns-host=https://mynightscout.azurewebsites.net --start-date=YYYY-MM-DD`


### PR DESCRIPTION
Incorrect start time formats in profile.json (& pumprofile.json, autotune.json) lead to erroneous calculations for CR & ISF.  Added an additional point in "Other things to check" to highlight with examples of errors produced with incorrect time format strings.