### PR TITLE
Add additional clarifying note that maxIOB can limit SMB.

### DIFF
--- a/docs/docs/Customize-Iterate/oref1.md
+++ b/docs/docs/Customize-Iterate/oref1.md
@@ -30,6 +30,8 @@ Single SMB amounts are limited by several factors.  The largest a single SMB bol
 * 1/3 of the Insulin Required amount, or
 * the remaining portion of your maxIOB setting in preferences
 
+It's important to note that maxIOB will limit SMBs from being issued if your IOB (for instance, from an easy bolus you have inputted before a meal) exceeds your maxIOB. So if your maxIOB is relatively low and you are running high post-meal, you may want to examine your logs to see if it is routinely preventing SMBs.
+
 (History of SMB development: https://github.com/openaps/oref0/issues/262)
 
 ## Understanding UAM 


### PR DESCRIPTION
Trying to add a note to explain that easy bolus can push you up to your maxIOB cap and block SMB. Dana/Scott, it may be worth adding something like this to the 0.6.0 release notes since this is a significant change for those of us coming from 0.5.x used to using bolus wizard, which did not count against the maxIOB cap.