### PR TITLE
Update Nightscout branch from `master` to `dev` as per 0.6.0 release …

### DIFF
--- a/docs/docs/While You Wait For Gear/nightscout-setup.md
+++ b/docs/docs/While You Wait For Gear/nightscout-setup.md
@@ -40,6 +40,8 @@ your data, customized watchfaces with your OpenAPS data, and integration with IF
 
 ![Fork example](../Images/nightscout/ns_fork.jpg)
 
+* Where it says `Branch: master` (to the far-left of the green "Clone or download" button), click on it and choose `dev`. This button should then say `Branch: dev`.
+
 * Scroll down until you see the purple `Deploy to Heroku` button.  Click that button.
 
 ![Deploy to heroku button](../Images/nightscout/deploy_heroku.jpg)


### PR DESCRIPTION
…notes

As per the 0.6.0 release notes, we need - as of 2017-11-30 at least - to deploy Nightscout's `dev` branch rather than its `master`.

I suspect that this change may not be needed for very long, but that assumes that the 112 changes in NS's `dev` make their way quickly into NS's `master`.