### PR TITLE
Reduce confusion about compatible pumps

### DIFF
--- a/docs/docs/Gear Up/pump.md
+++ b/docs/docs/Gear Up/pump.md
@@ -16,7 +16,7 @@ NOTE: For European/WorldWide users who have access to a `DANA*R` insulin pump, y
 
 ## How to check 523/723 & 554/754 pump firmware (check for absence of PC Connect)
 
-Note: his does not apply to the 512/712, 515/715 nor 523/723 pumps as their menues do not have a "Connect Devices" sub-menu within "Utilities". Any functioning x12, x15 or x22 pump will work, there is no need to check the firmware.
+Note: his does not apply to the 512/712, 515/715 nor 522/722 pumps as their menues do not have a "Connect Devices" sub-menu within "Utilities". Any functioning x12, x15 or x22 pump will work, there is no need to check the firmware.
 
 The firmware version will briefly display after the initial count-up on a new battery insertion.  After the pump has been on for awhile, you can check firmware version by using the Esc button on the pump and scroll all the way to the bottom of the screen messages using the down arrow on pump. 
 

--- a/docs/docs/Gear Up/pump.md
+++ b/docs/docs/Gear Up/pump.md
@@ -14,7 +14,9 @@ Currently, only the following Medtronic MiniMed models allow us to remotely set 
 
 NOTE: For European/WorldWide users who have access to a `DANA*R` insulin pump, you may be able to use AndroidAPS, which leverages OpenAPS's oref0 algorithm but allows you to interface using an Android phone and Bluetooth to communicate directly with the `DANA*R` pump. [See here for instructions and details related to AndroidAPS](https://github.com/MilosKozak/AndroidAPS).
 
-## How to check pump firmware (check for absence of PC Connect)
+## How to check 523/723 & 554/754 pump firmware (check for absence of PC Connect)
+
+Note: his does not apply to the 512/712, 515/715 nor 523/723 pumps as their menues do not have a "Connect Devices" sub-menu within "Utilities". Any functioning x12, x15 or x22 pump will work, there is no need to check the firmware.
 
 The firmware version will briefly display after the initial count-up on a new battery insertion.  After the pump has been on for awhile, you can check firmware version by using the Esc button on the pump and scroll all the way to the bottom of the screen messages using the down arrow on pump. 
 


### PR DESCRIPTION
I have never before been a Medtronic pump user (always Roche, perhaps that's a European thing). 

When trying to find a pump suitable for use with OpenAPS I was confused about the "How to check pump firmware (check for absence of PC Connect)" section - I had asked the seller of a 722 pump about the "Connect Devices" menu under "Utilities". We both ended up confused.

The intention here is to clarify that the x12, x15 and x22 pumps do not need to have their firmware checked.