### PR TITLE
Update how-openaps-works-overview.md

### DIFF
--- a/docs/docs/Understanding OpenAPS-Overview/how-openaps-works-overview.md
+++ b/docs/docs/Understanding OpenAPS-Overview/how-openaps-works-overview.md
@@ -3,9 +3,9 @@
 How do you make decisions about your diabetes? You gather data, crunch the numbers, and take action. 
 
 A DIY loop is no different. It gathers data from:
-* your pump
-* your CGM
-* any other place you log data, like Nightscout
+* [your pump](https://openaps.readthedocs.io/en/latest/docs/Gear%20Up/pump.html)
+* [your CGM](https://openaps.readthedocs.io/en/latest/docs/Gear%20Up/CGM.html)
+* any other place you log data, like [Nightscout](https://openaps.readthedocs.io/en/latest/docs/While%20You%20Wait%20For%20Gear/nightscout-setup.html)
 
 It then uses this information to do the math and decide how your basal rates might need to be adjusted (above or below your underlying basal rate), to adjust and eventually keep or bring your BGs into your target range. 
 
@@ -23,7 +23,7 @@ The rig runs a series of commands to collect this data, runs it through the algo
 
 When you build an OpenAPS rig, you run through the setup described in this documentation, and:
 * physically put your rig together
-* load the open source software on it
+* [load the open source software on it](https://openaps.readthedocs.io/en/latest/docs/Build%20Your%20Rig/OpenAPS-install.html)
 * configure it to talk to YOUR devices and have your information and safety settings on it (based on your preferences)
 
 The open source software is designed to make it easy for the computer to do the work you used to do to calculate what needs to be done. It runs a series of reports to collect data from all the devices and places. Then it prepares the data and runs the calculations. Then it attempts to communicate and send any necessary adjustments to your pump. Then it reads the data back, and does it over and over again. 


### PR DESCRIPTION
Links to various parts of the instructions to make it a little easier to navigate, I also would like to put together a section under build your rig with construction instructions, pictures and common questions asked my the community, I think this is important, once complete I will add a hyperlink in this page for 'physically put your rig together' to that page.
Please let me know if this is something already in the works to avoid double up.