### PR TITLE
Update entering-carbs-bolus.md

### DIFF
--- a/docs/docs/While You Wait For Gear/entering-carbs-bolus.md
+++ b/docs/docs/While You Wait For Gear/entering-carbs-bolus.md
@@ -22,6 +22,7 @@ Look at this image for the big picture:
 
 * You can still use the bolus wizard to enter carbs, although it must be entered with the smallest unit of bolus (.1 or .05, depending on your pump). Otherwise, OpenAPS will ignore those carbs.
 * Some pumps can use the ['meal marker' feature](http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/offline-looping-and-monitoring.html#entering-carbs-while-offline).
+* See section on [extended and dual wave substitutes](https://openaps.readthedocs.io/en/latest/docs/While%20You%20Wait%20For%20Gear/collect-data-and-prepare.html#extended-and-dual-wave-substitute) for information on how extended boluses are handled in OpenAPS.
 
 ### Online carb entry
 


### PR DESCRIPTION
Have added a link to the 'Extended and Dual wave substitutes' section of 'Collect your data and get prepared' as many people use dual and square wave boluses pre-looping and the info on how to manage this with OpenAPS is helpful.