### PR TITLE
Add alternate Jubilinux download location

### DIFF
--- a/docs/docs/Resources/Edison-Flashing/PC-flash.md
+++ b/docs/docs/Resources/Edison-Flashing/PC-flash.md
@@ -1,4 +1,4 @@
-# Setting up Edison/Explorer Board on Windows/PC 
+﻿# Setting up Edison/Explorer Board on Windows/PC 
 
 (This is testing a separate workflow for Windows only. Please refer to the [main Edison setup guide](./all-computers-flash.html) as well for troubleshooting & full instructions for other computer setup processes.)
 
@@ -59,7 +59,9 @@ Windows PCs with less than 6 GB of RAM  may need to have the size of the page fi
 
 #### Download jubilinux and dfu-util
 
-- Download Jubilinux (jubilinux version 0.2.0 is the latest version known to work, jubilinux 0.3.0 does NOT work yet) [jubilinux.zip](http://www.jubilinux.org/dist/).  Jubilinux will download in a zipped format to your Downloads folder.  Locate the folder in your Downloads and right-click the `jubilinux.zip` folder.  Select `extract all` from the menu.  Saving it to your root user directory is a good idea.  Your root directory is the set of folders that exist under your User name in Windows.  For example, the destination for saving jubilinux to your root directory would be `C:\Users\yourusername\jubilinux`
+- Download [Jubilinux](http://www.jubilinux.org/dist/) (jubilinux version 0.2.0 is the latest version known to work, jubilinux 0.3.0 does NOT work yet).  Jubilinux will download in a zipped format to your Downloads folder.  Locate the folder in your Downloads and right-click the `jubilinux.zip` folder.  Select `extract all` from the menu.  Saving it to your root user directory is a good idea.  Your root directory is the set of folders that exist under your User name in Windows.  For example, the destination for saving jubilinux to your root directory would be `C:\Users\yourusername\jubilinux`
+
+*(If the Jubilinux website is down, you can download [jubilinux-v0.2.0.zip](https://files.aps.builders/jubilinux-v0.2.0.zip) from [here](https://files.aps.builders/jubilinux-v0.2.0.zip))*
 
 **Note** The `extract all` command comes standard for all Windows machines.  However, in some instances, it may not be active for zipped files. If you do not see the `extract all` option in the right-click menu, right-click the zipped file, choose `Properties` at the bottom of the context menu.  On the General tab, click on the button next to the "opens with" and change it to use Windows Explorer.  Apply the change and select `OK` to save the change.  You should now be able to right-click the jubilinux.zip file to extract all.
 

--- a/docs/docs/Resources/Edison-Flashing/all-computers-flash.md
+++ b/docs/docs/Resources/Edison-Flashing/all-computers-flash.md
@@ -1,4 +1,4 @@
-# Setting Up Your Intel Edison - Flashing instructions for all computer types
+﻿# Setting Up Your Intel Edison - Flashing instructions for all computer types
 
 The Intel Edison system comes with a very limited Operating System. It's best to replace this with a custom version of Debian, as this fits best with OpenAPS, and it also means you have the latest security and stability patches. (These setup instructions were pulled from the mmeowlink wiki; if you're an advanced user and want/need to use Ubilinux instead of the recommended Jubilinux, [go here](https://github.com/oskarpearson/mmeowlink/wiki/Prepare-the-Edison-for-OpenAPS).) The setup instructions also are going to assume you're using the Explorer Board that has a built in radio stick. If you're using any other base board and/or any other radio sticks (TI, ERF, Rileylink, etc.), check out [the mmeowlink wiki](https://github.com/oskarpearson/mmeowlink/wiki) for support of those hardware options.
 
@@ -56,7 +56,8 @@ Windows PCs with less than 6 GB of RAM  may need to have the size of the page fi
 ### Jubilinux
 [Jubilinux](http://www.jubilinux.org/) "is an update to the stock ubilinux edison distribution to make it more useful as a server, most significantly by upgrading from wheezy to jessie."  That means we can skip many of the time-consuming upgrade steps that are required when starting from ubilinux.
 
-  - Download Jubilinux [jubilinux.zip](http://www.jubilinux.org/dist/) - the 	jubilinux-v0.2.0.zip is known to work, version 0.3.0 does NOT work yet.
+  - Download [Jubilinux](http://www.jubilinux.org/dist/) - the 	jubilinux-v0.2.0.zip is known to work, version 0.3.0 does NOT work yet. 
+  *(If the Jubilinux website is down, you can download [jubilinux-v0.2.0.zip](https://files.aps.builders/jubilinux-v0.2.0.zip) from [here](https://files.aps.builders/jubilinux-v0.2.0.zip))*
   - In download folder, right-click on file and extract (or use `unzip jubilinux.zip` from the command line) You will access this directory from a command prompt in the next step. It is a good idea to create the Jubilinux in your root directory to make this easier to access.
   - Open a terminal window and navigate to the extracted folder: `cd jubilinux`. If using Windows OS use the command prompt (cmd). This is your "flash window", keep it open for later.
   

--- a/docs/docs/Resources/Edison-Flashing/mac-flash.md
+++ b/docs/docs/Resources/Edison-Flashing/mac-flash.md
@@ -1,4 +1,4 @@
-# Setting up Edison/Explorer Board on a Mac
+﻿# Setting up Edison/Explorer Board on a Mac
 
 (This is a separate workflow for Mac only. Please refer to the all-computer flashing instructions as well for troubleshooting & full instructions for other computer setup processes.)
 
@@ -46,7 +46,7 @@ Building the software into your rig is comprised of three steps:
 
 The Edison comes with an operating system that doesn’t work easily with OpenAPS.  The first step is to replace the operating system with a new one.  This is called “flashing” the Edison.  
 
-Let’s start by downloading the updated operating system (it’s called Jubilinux) to your computer so that we can install it later onto the Edison.  Go to Safari and download Jubilinux (jubilinux 0.2.0 is the latest version known to work, jubilinux 0.3.0 does NOT work yet). [jubilinux.zip](http://www.jubilinux.org/dist/)
+Let’s start by downloading the updated operating system (it’s called Jubilinux) to your computer so that we can install it later onto the Edison.  Go to Safari and download [Jubilinux](http://www.jubilinux.org/dist/) (jubilinux 0.2.0 is the latest version known to work, jubilinux 0.3.0 does NOT work yet).  *(If the Jubilinux website is  down, you can download [jubilinux-v0.2.0.zip](https://files.aps.builders/jubilinux-v0.2.0.zip) from [here](https://files.aps.builders/jubilinux-v0.2.0.zip))*
 
 Now we move to the Edison.  You’ll see two microB USB ports on your explorer board.  One is labeled OTG (that’s for flashing) and one is labeled UART (that’s for logging into the Edison from a computer).  We will need to use both to flash.  We’re going to plug both of those into our computer’s USB ports using the cables listed in the parts list (Dexcom’s charging cable will work too). 
 


### PR DESCRIPTION
Added an alternate download location for jubilinux-v0.2.0.zip (In case the main jubilinux website is down) + changed jubilinux.zip hyperlink to jubilinux because it's not pointing to a file but a directory