### PR TITLE
Re-Run Autotune After Initial 'One-Off' Set-up

### DIFF
--- a/docs/docs/Customize-Iterate/autotune.md
+++ b/docs/docs/Customize-Iterate/autotune.md
@@ -274,6 +274,24 @@ oref0-autotune --dir=~/myopenaps --ns-host=https://mynightscout.herokuapp.com --
 * When starting out with autotune, you may find your basals settings are far enough below your real basal rates for the algorithm to classify periods when basals are too low as unannounced meals. In this case, if you are certain you have entered all carb intake events, you can force the algorithm to classify unannounced meal periods as basal periods using the --categorize-uam-as-basal=true option. **\*\*SAFETY WARNING\*\*** If you use this option and treat lows due to basals that are too high without entering the low treatment carbs, an amplifying cycle will begin with autotune raising basals, treated lows get categorizes as basals being too low, basals are raised causing lows, etc.
 * Remember, this is currently based on *one* ISF and carb ratio throughout the day at the moment. Here is the [issue](https://github.com/openaps/oref0/issues/326) if you want to keep track of the work to make autotune work with multiple ISF or carb ratios.
 
+#### Re-Running Autotune
+
+Remember, to initially set-up Autotune follow the instructions [above](https://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html#phase-c-running-autotune-for-suggested-adjustments-without-an-openaps-rig)
+
+To subsequently re-run Autotune at a later time:
+* Open Ubuntu/your machine of choice and login if necessary
+* At command prompt which will start with your username: `cd ~/myopenaps/settings`
+* Then: `nano profile.json` (this gets you to the pump settings section)
+  * Now edit your settings (using up / down arrows and backspace) – CR; ISF; basals etc. 
+  * Press Control-X    (to save your new settings)
+  * Press Y   (to confirm save new settings)
+* Now should see command prompt which will start with your user name again.
+* Now follow steps D, E, F from the link above ie:
+  * `jq . profile.json `(if it prints a colourful version of your profile.json, you’re good to proceed) 
+  * `cp profile.json pumpprofile.json`
+  * `cp profile.json autotune.json`
+* Then to re-run Autotune, subbing in your URL: `oref0-autotune --dir=~/myopenaps --ns-host=https://mynightscout.herokuapp.com --start-date=YYYY-MM-DD`
+
 #### Why Isn't It Working At All?
 
 (First - breathe, and have patience!) Here are some things to check: 
@@ -327,32 +345,3 @@ Remember, autotune is still a work in progress (WIP). Please provide feedback al
 #### Yay, It Worked! This is Cool!
 
 Great! We'd love to hear if it worked well, plus any additional feedback - please also provide input via this short [Google form](https://goo.gl/forms/Cxbkt9H2z05F93Mg2) and/or comment on [this issue in Github](https://github.com/openaps/oref0/issues/261) for more detailed feedback about the tool. You can also help us tackle some of the known issues and feature requests listed [here](./understanding-autotune.md). 
-
-How to Re-run Autotune After Initial ‘One-Off’ Set-up
-
-To initially set-up Autotune follow these instructions: https://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html#phase-c-running-autotune-for-suggested-adjustments-without-an-openaps-rig
-
-To subsequently Re-run Autotune:
-Open Ubuntu       (and enter password for Unix if asked)
-At command prompt which will start with your username type: cd ~/myopenaps/settings
-	PRESS ENTER
-Now type: nano profile.json       (this gets you to the pump settings section)
-	PRESS ENTER
-Now edit your settings (using up / down arrows and backspace) – CR; ISF; basals etc
-Press Control-X    (to save your new settings)
-Press Y   (to confirm save new settings)
-	PRESS ENTER
-Now should see command prompt which will start with your user name again.
-Now follow steps D, E, F from the link above ie:
-Type:  jq . profile.json 
-	PRESS ENTER   (if it prints a colourful version of your profile.json, you’re good to proceed) 
-Type: cp profile.json pumpprofile.json
-	PRESS ENTER
-Type: cp profile.json autotune.json
-	PRESS ENTER
-Type the following command to run Autotune: oref0-autotune --dir=~/myopenaps --ns-host=https://mynightscout.herokuapp.com --start-date=YYYY-MM-DD 
-
-	(Sub in your Nightscout URL for “mynightscout.herokuapp.com” in the line above)
-
-	PRESS ENTER
-

--- a/docs/docs/Customize-Iterate/autotune.md
+++ b/docs/docs/Customize-Iterate/autotune.md
@@ -327,3 +327,32 @@ Remember, autotune is still a work in progress (WIP). Please provide feedback al
 #### Yay, It Worked! This is Cool!
 
 Great! We'd love to hear if it worked well, plus any additional feedback - please also provide input via this short [Google form](https://goo.gl/forms/Cxbkt9H2z05F93Mg2) and/or comment on [this issue in Github](https://github.com/openaps/oref0/issues/261) for more detailed feedback about the tool. You can also help us tackle some of the known issues and feature requests listed [here](./understanding-autotune.md). 
+
+How to Re-run Autotune After Initial ‘One-Off’ Set-up
+
+To initially set-up Autotune follow these instructions: https://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html#phase-c-running-autotune-for-suggested-adjustments-without-an-openaps-rig
+
+To subsequently Re-run Autotune:
+Open Ubuntu       (and enter password for Unix if asked)
+At command prompt which will start with your username type: cd ~/myopenaps/settings
+	PRESS ENTER
+Now type: nano profile.json       (this gets you to the pump settings section)
+	PRESS ENTER
+Now edit your settings (using up / down arrows and backspace) – CR; ISF; basals etc
+Press Control-X    (to save your new settings)
+Press Y   (to confirm save new settings)
+	PRESS ENTER
+Now should see command prompt which will start with your user name again.
+Now follow steps D, E, F from the link above ie:
+Type:  jq . profile.json 
+	PRESS ENTER   (if it prints a colourful version of your profile.json, you’re good to proceed) 
+Type: cp profile.json pumpprofile.json
+	PRESS ENTER
+Type: cp profile.json autotune.json
+	PRESS ENTER
+Type the following command to run Autotune: oref0-autotune --dir=~/myopenaps --ns-host=https://mynightscout.herokuapp.com --start-date=YYYY-MM-DD 
+
+	(Sub in your Nightscout URL for “mynightscout.herokuapp.com” in the line above)
+
+	PRESS ENTER
+


### PR DESCRIPTION
This adds a step by step guide to how to re-run Autotune after initial 'One-Off' set-up.  I've put together a simple step-by-step guide on how to re-run Autotune manually once it has been set-up for 'One Off' use according to the OpenAPS Docs - these steps are for non-OpenAPS users to help tune settings for Loop or non-loopers. These steps are probably really obvious for the 'techies' out there but I'm not one of those and it took me a bit of figuring out - I thought this might help someone else after I put it together for my use. Sorry about my lack of formatting! It looked okay in the Word document version I put together but all the formatting vanished when pasting it here. As I mentioned, tech isn't my strength so I don't know how to format it nicely here to match the rest of the Docs. You're welcome to incorporate it if you like, I won't be the least bit offended if you don't or if you revise it significantly. I do think some instruction on how to do this and indeed pointing out that it can be done without repeating the entire initial One-Off Autotune set-up process might encourage more Loop users and 'non-loopers' to use Autotune. I was pleased to figure out I didn't have to type all the pump basal settings command lines etc each time I wanted to run Autotune manually, that in fact I could just edit the numbers then run it again.