### PR TITLE
adding a way to add carbs in Nightscout

### DIFF
--- a/docs/docs/While You Wait For Gear/entering-carbs-bolus.md
+++ b/docs/docs/While You Wait For Gear/entering-carbs-bolus.md
@@ -32,3 +32,5 @@ If your rig is online, you have a variety of ways to enter carbs online.
   * Pebble or Apple watch
   * Google Calendar
   * Siri, Alexa, Google, etc. 
+* Android users: you can use the Care portal option in [NSClient app found here](https://github.com/nightscout/NSClient-Android/releases).
+  


### PR DESCRIPTION
added the last line for Android users (NSClient) as we use it to log carbs into Nightscout, that way we don't need to use the bolus wizard.