### PR TITLE
Add warning  for Enlite users

### DIFF
--- a/docs/docs/Customize-Iterate/usability-considerations.md
+++ b/docs/docs/Customize-Iterate/usability-considerations.md
@@ -116,7 +116,9 @@ Some users who switch to Fiasp find that they need to adjust settings. Others do
 
 ## Improving the battery life of your Raspberry Pi
 
-Version - CPU Clock - Battery Life @ 2500mAh
+!! Important for Enlite users: If you are using Enlite as CGM source, your rig will not work when it's underclocked, since the loop will not run fast enough! (You will always see the "BG too old" error). We are aware of that issue and try to find a solution...
+
+Version - CPU Clock - Battery Life @ 2500mAh (Li-Po)
 ___
 * 0.6.2 - 1000 MHz - **8 hours**
 * 0.7.0-dev - 1000 MHz - **9 hours**


### PR DESCRIPTION
OpenAPS is not working with underclocked Pi rigs since the loop runs so slow that bg values get outdated till they are processed. This issue has been reported several times on gitter and observed by myself.