### PR TITLE
Adds additional phone to Bluetooth Tethering Doc + Adds note to offline looping and monitoring  

### DIFF
--- a/docs/docs/Customize-Iterate/bluetooth-tethering-edison.md
+++ b/docs/docs/Customize-Iterate/bluetooth-tethering-edison.md
@@ -51,6 +51,7 @@ Certain phones don't work well using bluetooth tethering with OpenAPS. Various u
 <TR><TH>Motorolo Moto Z Play<TD>Yes<TD>Excellent BT tethering; highly reliable using Blue Car Tethering.<TD>Not tested (using Enlite sensor).
 <TR><TH>Wiko Wim Lite<TD>Intermittent<TD>Works most of the time. Note, several issues with this phone: 1) NSClient has a tendency to crash on this phone and 2) Bluetooth tethering works intermittently with Blue Car Autotether and not at all with BT AutoTether. Note that this phone has a tendency to freeze and reboot on its own, so I think the phone itself is the issue.<TD>Not tested (using Enlite sensor).
 <TR><TH>Xiaomi Mi Mix 2 with LineageOS 15.1<TD>Yes<TD>Excellent connectivity - has worked almost flawlessly with tethering. Battery life has also been very good.<TD>Works brilliantly with xDrip+ and G6 - capture rate typically more than 95%.      
+<TR><TH>Nokia 2.1 with Android 8.1 Oreo Go Edition<TD>Yes<TD>Excellent bluetooth tethering to cellular network. No noted network drops. Works excellent as an offline option with XDripAPS. Awesome battery life(4000mAH)<TD>Works well with Dexcom G5 and xDrip. No issues with compatibility. Generally 95%+ capture rate.
 </TABLE>
 
 **********************************************************************************************

--- a/docs/docs/Customize-Iterate/offline-looping-and-monitoring.md
+++ b/docs/docs/Customize-Iterate/offline-looping-and-monitoring.md
@@ -274,6 +274,8 @@ https://<nightscout_api_secret>@<yournnightscoutsite>.herokuapp.com/api/v1/ http
 ```
 Be careful when entering the addresses - xDripAPS uses the http protocol, Nightscout uses the https protocol.
 
+NOTE: To ensure your OpenAPS rig recieves glucose data through XdripAPS please confirm the following setting is UN-CHECKED : Open XDrip + and navigate to Settings > Cloud Upload > Nightscout Sync (REST-API) > Extra options > "Skip LAN uploads". This setting is checked by default, however does not allow your openaps rig to recieve glucose data when tethered offline.
+
 </details>
 <br>
    


### PR DESCRIPTION
Updates bluetooth-tethering-edison.md - Adds additional phone option that I have tested over the past week without issues.

Updates  offline-looping-and-monitoring.md with the following "NOTE: To ensure your OpenAPS rig recieves glucose data through XdripAPS please confirm the following setting is UN-CHECKED : Open XDrip + and navigate to Settings > Cloud Upload > Nightscout Sync (REST-API) > Extra options > "Skip LAN uploads". This setting is checked by default, however does not allow your openaps rig to recieve glucose data when tethered offline."