### PR TITLE
Hardware for attaching Explorer block to Intel Edison

### DIFF
--- a/docs/docs/Gear Up/edison.md
+++ b/docs/docs/Gear Up/edison.md
@@ -98,7 +98,7 @@ You may want to connect your Dexcom receiver (G4 or non-touchscreen G5) to your 
 
 ### Nuts and Bolts
 
-You will likely want to screw your Edison onto the Explorer Block to stabilize the rig. There are two methods to do this.  The simplest is to order a kit like the [Sparkfun Intel Edison Hardware Pack](https://www.sparkfun.com/products/13187), which provides standoffs, screws, and nuts specifically designed for the Edison. Alternatively, you can use (2) M2 screws and (2) M2 nuts and (4)  M3 nuts (M3 or a bit larger to used as spacers).  In this configuration, the screws should be just long enough to fit through the spacer nuts and screw into the M2 nuts on the other side. (Note: Sparkfun is no longer selling these screw kits. There were some available in April 2018 at [Mouser](https://www.mouser.com/productdetail/sparkfun/com-13187?qs=WyAARYrbSnZmROJb2S4FFw%3D%3D).
+You will likely want to screw your Edison onto the Explorer Block to stabilize the rig. There are two methods to do this.  The simplest is to order a kit like the [Sparkfun Intel Edison Hardware Pack](https://www.sparkfun.com/products/13187), which provides standoffs, screws, and nuts specifically designed for the Edison. Alternatively, you can use (2) M2 screws and (2) M2 nuts and (4)  M3 nuts (M3 or a bit larger to used as spacers).  In this configuration, the screws should be just long enough to fit through the spacer nuts and screw into the M2 nuts on the other side. (Note: Sparkfun is no longer selling these screw kits. There are some available on Amazon [lock nuts](https://www.amazon.com/Uxcell-a15072100ux0228-Plated-Nylock-Insert/dp/B015A3BZJQ) and [cap screws](https://www.amazon.com/iExcell-Stainless-Steel-Socket-Screws/dp/B07FLLGW19).
 
 ### Cases
 


### PR DESCRIPTION
I was unable to purchase the hardware from the links provided in docs, and I found that regular nuts loosen up over time so I switched to lock nuts 