### PR TITLE
Additional text for 640G CGM users as below

### DIFF
--- a/docs/docs/Build Your Rig/OpenAPS-install.md
+++ b/docs/docs/Build Your Rig/OpenAPS-install.md
@@ -58,8 +58,9 @@ The screenshot below shows an example of the questions you'll be prompted to rep
 * whether you are using an Explorer board
    * if not an Explorer board, and not a Carelink stick, you'll need to enter the mmeowlink port for TI stick.  See [here](https://github.com/oskarpearson/mmeowlink/wiki/Installing-MMeowlink) for directions on finding your port
     * if you're using a Carelink, you will NOT be using mmeowlink. After you finish setup you need to check if the line `radio_type = carelink` is present in your `pump.ini` file.
-* CGM method:  The options are `g4-upload`, `g4-local-only`, `g5`, `mdt`, and `xdrip`.  
+* CGM method:  The options are `g4-upload`, `g4-local-only`, `g5`, `mdt`, and `xdrip`.
    * Note:  OpenAPS also attempts to get BG data from your Nightscout.  OpenAPS will always use the most recent BG data regardless of the source. As a consequence, if you use FreeStyle Libre or any other CGM system that gets its data only from Nightscout, you'll be fine choosing any of the options above. 
+   * Note:  For Medtronic 640G (CGM) users, it is recommended that you enter 'xdrip' - otherwise the BG values may not be read from your Nightscout. (The reason being, the 'MDT' option applies only for the enlite sensor attached to the actual pump you're looping with)
    * Note: G4-upload will allow you to have raw data when the G4 receiver is plugged directly into the rig.
 * Nightscout URL and API secret (or NS authentication token, if you use that option)
 * BT MAC address of your phone, if you want to pair for BT tethering to personal hotspot (letters should be in all caps)


### PR DESCRIPTION
Some 640G users may (as I did) may choose the MDT option as their CGM during the set up. If this is done,then the algorithm will look to pull the BG data directly from the looping pump instead of NS (which gets its data from the 640G)   

'Note:  For Medtronic 640G (CGM) users, it is recommended that you enter 'xdrip' - otherwise the BG values may not be read from your Nightscout. (The reason being, the 'MDT' option applies only for the enlite sensor attached to the actual pump you're looping with)'