### PR TITLE
Added one instruction

### DIFF
--- a/docs/docs/Build Your Rig/pi-install.md
+++ b/docs/docs/Build Your Rig/pi-install.md
@@ -93,6 +93,8 @@ Now we will select a Raspian-compatible updated branch by using `cd ~/src/oref0 
 
 First, update npm to the latest version. Run `npm install npm@latest -g`. 
 
+Next, change to the oref0 directory if you are not in it already. Run `cd ~/src/oref0`. 
+
 Now run `npm run global-install`.  After about 10-15 minutes, the installations will end and you will be dropped off at the `root@yourrigname:~/src/oref0#` prompt.  Successful completion of this step should look like below.
 
 !["install piBakery"](../Images/build-your-rig/pi-install-success.png)


### PR DESCRIPTION
When I ran through the instructions as they were, npm run global-install failed. It could not find package.json because I was not in the ~/src/oref0 directory. I would have been in this directory had I followed "Switch to dev branch for your pi HAT" but I am not using an RFM69HCW. Instead I jumped to finish installation from line 76.