### PR TITLE
Migrate to Jubilinux 0.3.0 (stretch)

### DIFF
--- a/docs/docs/Build Your Rig/edison-install.md
+++ b/docs/docs/Build Your Rig/edison-install.md
@@ -48,8 +48,8 @@ ifdown wlan0; ifup wlan0
 sleep 10
 echo -ne "\nWifi SSID: "; iwgetid -r
 sleep 5
-curl https://raw.githubusercontent.com/openaps/oref0/master/bin/openaps-install.sh > /tmp/openaps-install.sh
-bash /tmp/openaps-install.sh
+curl https://raw.githubusercontent.com/openaps/oref0/dev/bin/openaps-install.sh > /tmp/openaps-install.sh
+bash /tmp/openaps-install.sh dev
 )
 ```
 

--- a/docs/docs/Resources/Edison-Flashing/PC-flash.md
+++ b/docs/docs/Resources/Edison-Flashing/PC-flash.md
@@ -59,9 +59,7 @@ Windows PCs with less than 6 GB of RAM  may need to have the size of the page fi
 
 #### Download jubilinux and dfu-util
 
-- Download [Jubilinux](http://www.jubilinux.org/dist/) (jubilinux version 0.2.0 is the latest version known to work, jubilinux 0.3.0 does NOT work yet).  Jubilinux will download in a zipped format to your Downloads folder.  Locate the folder in your Downloads and right-click the `jubilinux.zip` folder.  Select `extract all` from the menu.  Saving it to your root user directory is a good idea.  Your root directory is the set of folders that exist under your User name in Windows.  For example, the destination for saving jubilinux to your root directory would be `C:\Users\yourusername\jubilinux`
-
-*(If the Jubilinux website is down, you can download [jubilinux-v0.2.0.zip](https://files.aps.builders/jubilinux-v0.2.0.zip) from [here](https://files.aps.builders/jubilinux-v0.2.0.zip))*
+- Download [Jubilinux](http://www.jubilinux.org/dist/) (jubilinux version 0.3.0 is the current version known to work, jubilinux 0.2.0 does NOT work anymore).  Jubilinux will download in a zipped format to your Downloads folder.  Locate the folder in your Downloads and right-click the `jubilinux.zip` folder.  Select `extract all` from the menu.  Saving it to your root user directory is a good idea.  Your root directory is the set of folders that exist under your User name in Windows.  For example, the destination for saving jubilinux to your root directory would be `C:\Users\yourusername\jubilinux`
 
 **Note** The `extract all` command comes standard for all Windows machines.  However, in some instances, it may not be active for zipped files. If you do not see the `extract all` option in the right-click menu, right-click the zipped file, choose `Properties` at the bottom of the context menu.  On the General tab, click on the button next to the "opens with" and change it to use Windows Explorer.  Apply the change and select `OK` to save the change.  You should now be able to right-click the jubilinux.zip file to extract all.
 

--- a/docs/docs/Resources/Edison-Flashing/all-computers-flash.md
+++ b/docs/docs/Resources/Edison-Flashing/all-computers-flash.md
@@ -56,8 +56,7 @@ Windows PCs with less than 6 GB of RAM  may need to have the size of the page fi
 ### Jubilinux
 [Jubilinux](http://www.jubilinux.org/) "is an update to the stock ubilinux edison distribution to make it more useful as a server, most significantly by upgrading from wheezy to jessie."  That means we can skip many of the time-consuming upgrade steps that are required when starting from ubilinux.
 
-  - Download [Jubilinux](http://www.jubilinux.org/dist/) - the 	jubilinux-v0.2.0.zip is known to work, version 0.3.0 does NOT work yet. 
-  *(If the Jubilinux website is down, you can download [jubilinux-v0.2.0.zip](https://files.aps.builders/jubilinux-v0.2.0.zip) from [here](https://files.aps.builders/jubilinux-v0.2.0.zip))*
+  - Download [Jubilinux](http://www.jubilinux.org/dist/) - the 	jubilinux-v0.3.0.zip is known to work, version 0.2.0 does NOT work anymore. 
   - In download folder, right-click on file and extract (or use `unzip jubilinux.zip` from the command line) You will access this directory from a command prompt in the next step. It is a good idea to create the Jubilinux in your root directory to make this easier to access.
   - Open a terminal window and navigate to the extracted folder: `cd jubilinux`. If using Windows OS use the command prompt (cmd). This is your "flash window", keep it open for later.
   

--- a/docs/docs/Resources/Edison-Flashing/mac-flash.md
+++ b/docs/docs/Resources/Edison-Flashing/mac-flash.md
@@ -46,7 +46,7 @@ Building the software into your rig is comprised of three steps:
 
 The Edison comes with an operating system that doesn’t work easily with OpenAPS.  The first step is to replace the operating system with a new one.  This is called “flashing” the Edison.  
 
-Let’s start by downloading the updated operating system (it’s called Jubilinux) to your computer so that we can install it later onto the Edison.  Go to Safari and download [Jubilinux](http://www.jubilinux.org/dist/) (jubilinux 0.2.0 is the latest version known to work, jubilinux 0.3.0 does NOT work yet).  *(If the Jubilinux website is  down, you can download [jubilinux-v0.2.0.zip](https://files.aps.builders/jubilinux-v0.2.0.zip) from [here](https://files.aps.builders/jubilinux-v0.2.0.zip))*
+Let’s start by downloading the updated operating system (it’s called Jubilinux) to your computer so that we can install it later onto the Edison.  Go to Safari and download [Jubilinux](http://www.jubilinux.org/dist/) (jubilinux 0.3.0 is the only version known to work, jubilinux 0.2.0 does NOT work anymore).
 
 Now we move to the Edison.  You’ll see two microB USB ports on your explorer board.  One is labeled OTG (that’s for flashing) and one is labeled UART (that’s for logging into the Edison from a computer).  We will need to use both to flash.  We’re going to plug both of those into our computer’s USB ports using the cables listed in the parts list (Dexcom’s charging cable will work too). 
 


### PR DESCRIPTION
- Updates Edison install docs to recommend Jubilinux v0.3.0 (stretch) install, rather than v0.2.0 (jessie), which has its upstream support deprecated (#1447 / https://github.com/openaps/oref0/issues/1236). 

- Switches the Edison bootstrap script to point to the `dev` branch, as `master` does not currently work on v0.3.0 (this should be reverted if there is a workaround, or once https://github.com/openaps/oref0/pull/1036 is merged)