### PR TITLE
Pass `dev` to openaps-install.sh

### DIFF
--- a/docs/docs/Build Your Rig/pi-install.md
+++ b/docs/docs/Build Your Rig/pi-install.md
@@ -60,7 +60,7 @@ Once you're logged in, run the following commands to start the OpenAPS install p
 
 ```
 sudo bash
-curl -s https://raw.githubusercontent.com/openaps/oref0/dev/bin/openaps-install.sh > /tmp/openaps-install.sh && bash /tmp/openaps-install.sh
+curl -s https://raw.githubusercontent.com/openaps/oref0/dev/bin/openaps-install.sh > /tmp/openaps-install.sh && bash /tmp/openaps-install.sh dev
 ```
 
 * Change your hostname (a.k.a, your rig's name). **Make sure to write down your hostname; this is how you will log in in the future as `ssh root@whatyounamedit.local`**
@@ -200,7 +200,7 @@ Once you're logged in, run the following commands to start the OpenAPS install p
 
 ```
 sudo bash
-curl -s https://raw.githubusercontent.com/openaps/oref0/dev/bin/openaps-install.sh > /tmp/openaps-install.sh && bash /tmp/openaps-install.sh
+curl -s https://raw.githubusercontent.com/openaps/oref0/dev/bin/openaps-install.sh > /tmp/openaps-install.sh && bash /tmp/openaps-install.sh dev
 ```
 
 You'll be prompted to set a password.  You'll want to change it to something personal so your device is secure. Make sure to write down/remember your password; this is what you'll use to log in to your rig moving forward. You'll type it twice.  There is no recovery of this password if you forget it.  You will have to start over from the top of this page if you forget your password.


### PR DESCRIPTION
If we want to install `dev`, we should tell openaps-install.sh to pull and install the `dev` branch.