### PR TITLE
Update troubleshooting for "Monitor/mmtune.json is empty or does not …

### DIFF
--- a/docs/docs/Resources/troubleshooting.md
+++ b/docs/docs/Resources/troubleshooting.md
@@ -250,6 +250,7 @@ cd ~/src/ccprog
 ./ccprog -p 19,7,36 write spi1_alt2_EDISON_EXPLORER_US_STDLOC.hex
 ```
 
+
 #### Using a Raspberry Pi + Explorer HAT:
 ```
 wget https://github.com/EnhancedRadioDevices/subg_rfspy/releases/download/v0.8-explorer/spi1_alt2_EDISON_EXPLORER_US_STDLOC.hex
@@ -259,6 +260,45 @@ wget https://github.com/EnhancedRadioDevices/subg_rfspy/releases/download/v0.8-e
 ```
 
   * Reboot, and try `killall -g oref0-pump-loop; openaps mmtune` to make sure it works
+  
+  
+### Monitor/mmtune.json is empty or does not exist
+#### Only verified to work with Intel Edison + Explorer Block
+Full error is:
+```
+cannot connect to CC111x radio on /dev/spidev5.1
+1999/12/31 19:14:23 cc111x: no response
+monitor/mmtune.json is empty or does not exist
+```
+Trying to reflash the radio may result in:
+```
+Erasing chip.
+This code is only tested on CC1110. Unsupported chip id = 0x00.
+Chip erase failed.
+```
+Also, the two LEDs next to the microUSB ports on your Explorer board are still on. Or they may flash during loop attempts, but stay on between loops. If this is the case, you may need to completely reinstall openAPS. This requires redoing everything from the Jubilinux flash, to the bootstrap script and finally the openAPS setup. 
+
+**Note:** Starting the Jubilinux flash from the beginning will overwrite everything, so you may want to copy and save any configuration files you don't want to lose, like your `wpa_supplicant.conf` Wi-Fi settings for example. 
+
+Instructions to reinstall openAPS are here: https://openaps.readthedocs.io/en/latest/docs/Build%20Your%20Rig/OpenAPS-install.html#step-1-jubilinux-for-edison-rigs-only
+
+Once you have finished running the openAPS setup script, view your loop by entering `l`. Your loop will probably still be failing, but with a different error message:
+```
+Could not get subg_rfspy state or version. Have you got the right port/device and radio_type?
+```
+Now you should be able to follow the directions above to reflash the radio: https://openaps.readthedocs.io/en/latest/docs/Resources/troubleshooting.html?highlight=ccprog#could-not-get-subg-rfspy-state-or-version-ccprog-or-cannot-connect-to-cc111x-radio
+This time the reflash should be successful and you should see:
+```
+Erasing chip.
+Chip erased.
+root@yourrig:~/src/ccprog# ./ccprog -p 19,7,36 write spi1_alt2_EDISON_EXPLORES_STDLOC.hex
+```
+Press enter, then you should see:
+```
+Writing 2769 bytes to flash....
+```
+You have now successfully reflashed the radio. Now `reboot` and your loop should start running with red and green LEDs off (except for an occasional blink).
+
 
 ## Dealing with the CareLink USB Stick
 

--- a/docs/docs/Resources/troubleshooting.md
+++ b/docs/docs/Resources/troubleshooting.md
@@ -276,17 +276,17 @@ Erasing chip.
 This code is only tested on CC1110. Unsupported chip id = 0x00.
 Chip erase failed.
 ```
-Also, the two LEDs next to the microUSB ports on your Explorer board are still on. Or they may flash during loop attempts, but stay on between loops. If this is the case, you may need to completely reinstall openAPS. This requires redoing everything from the Jubilinux flash, to the bootstrap script and finally the openAPS setup. 
+If you're affected by this particular issue, the two LEDs next to the microUSB ports on your Explorer board may stay on continuously, or they may flash during loop attempts, but stay on between loops. If this is the case, you may need to completely reinstall OpenAPS. This requires redoing everything from the Jubilinux flash, to the bootstrap script and finally the OpenAPS setup. 
 
 **Note:** Starting the Jubilinux flash from the beginning will overwrite everything, so you may want to copy and save any configuration files you don't want to lose, like your `wpa_supplicant.conf` Wi-Fi settings for example. 
 
-Instructions to reinstall openAPS are here: https://openaps.readthedocs.io/en/latest/docs/Build%20Your%20Rig/OpenAPS-install.html#step-1-jubilinux-for-edison-rigs-only
+Instructions to reinstall OpenAPS are [here](https://openaps.readthedocs.io/en/latest/docs/Build%20Your%20Rig/OpenAPS-install.html#step-1-jubilinux-for-edison-rigs-only)
 
-Once you have finished running the openAPS setup script, view your loop by entering `l`. Your loop will probably still be failing, but with a different error message:
+Once you have finished running the OpenAPS setup script, view your loop by entering `l`. Your loop will probably still be failing, but with a different error message:
 ```
 Could not get subg_rfspy state or version. Have you got the right port/device and radio_type?
 ```
-Now you should be able to follow the directions above to reflash the radio: https://openaps.readthedocs.io/en/latest/docs/Resources/troubleshooting.html?highlight=ccprog#could-not-get-subg-rfspy-state-or-version-ccprog-or-cannot-connect-to-cc111x-radio
+Now you should be able to follow [the directions above](https://openaps.readthedocs.io/en/latest/docs/Resources/troubleshooting.html?highlight=ccprog#could-not-get-subg-rfspy-state-or-version-ccprog-or-cannot-connect-to-cc111x-radio) to reflash the radio.
 This time the reflash should be successful and you should see:
 ```
 Erasing chip.


### PR DESCRIPTION
…exist" error

I had red and green LEDs on both of my rigs and the "Monitor/mmtune.json is empty or does not exist" error in my loop log. Both rigs were  running dev for several weeks before any problems. I used the above method to fix them both (loops started working again on master branch, have not switched to dev yet). This procedure has obviously not been vetted thoroughly, so it may be of limited use for the docs, but I figured I would document it and it might be a starting point if this is a commonly occurring problem. 

This is my first PR so I tried to integrate it into the existing troubleshooting section to the best of my ability. I also linked to other sections of the docs. I'm not sure how close I came to formatting this correctly, but it's better than inaction I suppose!