### PR TITLE
Change x12 instructions

### DIFF
--- a/docs/docs/Build Your Rig/OpenAPS-install.md
+++ b/docs/docs/Build Your Rig/OpenAPS-install.md
@@ -54,7 +54,6 @@ The screenshot below shows an example of the questions you'll be prompted to rep
 <br>
 
 * 6-digit serial number of your pump
-* whether you are using an 512/712 model pump (those require special setup steps that other model pumps do not)
 * whether you are using an Explorer board
    * if not an Explorer board, and not a Carelink stick, you'll need to enter the mmeowlink port for TI stick.  See [here](https://github.com/oskarpearson/mmeowlink/wiki/Installing-MMeowlink) for directions on finding your port
     * if you're using a Carelink, you will NOT be using mmeowlink. After you finish setup you need to check if the line `radio_type = carelink` is present in your `pump.ini` file.

--- a/docs/docs/Build Your Rig/x12-users.md
+++ b/docs/docs/Build Your Rig/x12-users.md
@@ -1,8 +1,10 @@
 # 512 and 712 Pump users
 
-If you have one of the x12 model pumps, you can still successfully use OpenAPS for basic looping (but not some advanced featuers like SMB).  You'll need to complete some extra setup tweaks before your loop will be successful, however.
+#### For releases 0.7.0 and beyond, all of this is done automatically; please skip this step.
 
-Note: If you have an old rig running oref0 0.5.3 or below, you'll need to follow historical instructions. The instructions below reflect the adjusted oref0-setup.sh in 0.6.0 and beyond, that does some of this work manually.
+Note: If you have an old rig running oref0 0.5.3 or below, you'll need to follow historical instructions. The instructions below reflect the adjusted oref0-setup.sh in 0.6.x which does some of this work manually. 
+
+If you have one of the x12 model pumps, you can still successfully use OpenAPS for basic looping (but not some advanced features like SMB).  You'll need to complete some extra setup tweaks before your loop will be successful, however.
 
 ## Most important step - make sure you said yes (y) in oref0-setup.sh 
 

--- a/docs/docs/Customize-Iterate/usability-considerations.md
+++ b/docs/docs/Customize-Iterate/usability-considerations.md
@@ -123,8 +123,6 @@ Some users who switch to Fiasp find that they need to adjust settings. Others do
 
 ## How do I switch to a different Medtronic pump?
 
-Please note that the procedure is likely different if switching to or from a 512 or 712 pump.
-
 First locate the serial number of the Medtronic pump you would like to start using. Then log into your rig and open your "runagain" script so you can edit the serial number.
 
 `cd ~/myopenaps && nano oref0-runagain.sh`

--- a/docs/docs/Gear Up/pump.md
+++ b/docs/docs/Gear Up/pump.md
@@ -25,7 +25,7 @@ A double-check for pump compatibility is to look for the ABSENCE of PC connect i
   * If "PC Connect" is absent, then the pump should be able to receive temp basal commands and be compatible.
  * If there is no "Connect Devices" menu, then the pump should be able to receive temp basal commands and be compatible.
    * This is the case for the 512/712, the 515/715 and 522/722 models. 
-   * For 512/712 pumps, certain commands like Read Settings, BG Targets and certain Read Basal Profile are not available, and require creating special files for the missing info to successfully run the loop ([Instructions for 512/712 users, click here](http://openaps.readthedocs.io/en/latest/docs/Build%20Your%20Rig/x12-users.html)). 512/712 users are not going to be able to use an advanced feature - (e)SMB - but will be able to do basic looping.
+   * For 512/712 pumps, you will not be able to use an advanced feature (SMB) but will be able to do basic temp-basal based looping.
 
 Note that not _all_ possible sellers of pumps will accuratly describe the model number: if they are willing to sell a pump they may not have interest in setting it up for looping, and the distinctions about model numbers and firmware version may not be important to them. It will be for you though! Therefore, it's prudent to verify the model by seeing pctures and/or videos of the pump in action. 
 

--- a/docs/docs/Resources/Edison-Flashing/mac-flash.md
+++ b/docs/docs/Resources/Edison-Flashing/mac-flash.md
@@ -6,7 +6,7 @@
 
 1.  Using an explorer board and Edison
 2.  Using an Apple computer
-3.  Using a looping-compatible Medtronic pump. If using a x12 series Medtronic pump, it will require one small [extra step](http://openaps.readthedocs.io/en/latest/docs/Build%20Your%20Rig/x12-users.html). See [all compatible pumps](http://openaps.readthedocs.io/en/latest/docs/Gear%20Up/pump.html#information-about-compatible-insulin-pumps). 
+3.  Using a looping-compatible Medtronic pump. See [all compatible pumps](http://openaps.readthedocs.io/en/latest/docs/Gear%20Up/pump.html#information-about-compatible-insulin-pumps). 
 
 ## High Level Recommended Rig parts list
 

--- a/docs/docs/Resources/switching-between-DIY-systems.md
+++ b/docs/docs/Resources/switching-between-DIY-systems.md
@@ -50,7 +50,7 @@ If you’re coming to try OpenAPS from a Loop system, there’s going to be some
 
 1.  Using an explorer board and Edison
 2.  Using an Apple computer
-3.  Using a Loop-compatible Medtronic pump (note - OpenAPS can actually use an additional set of pumps, the x12 series, although it requires one extra step not documented here. See this page in OpenAPS docs for all compatible pumps.)
+3.  Using a Loop-compatible Medtronic pump (note - OpenAPS can actually use an additional set of pumps, the x12 series, but it will be unable to use some advanced features like SMB. See this page in OpenAPS docs for all compatible pumps.)
 
 ### High Level Recommended Rig parts list
 

--- a/docs/docs/Troubleshooting/oref0-setup-troubleshooting.md
+++ b/docs/docs/Troubleshooting/oref0-setup-troubleshooting.md
@@ -44,7 +44,6 @@ Make sure to check through the following list before asking on Gitter if your se
 * Don't have data in Nightscout? Make sure there is no trailing slash `/` on the URL that you are entering and that the API secret is correct. Check your Nightscout URL, too - it's one of the most common errors to mistype that. (And FWIW, you shouldn't be typing things like that in the first place: that's what copy and paste are for.)
 * Check and make sure your receiver is >50% charged (if battery low, it may drain the rig battery and prevent it from operating).
 * A reboot may be required after running oref0-setup if the Carelink is unable to communicate with the pump (e.g. you see "Attempting to use a port that is not open" errors in pump-loop.log). Additional Carelink troubleshooting steps can be found in [Dealing with the CareLink USB Stick](http://openaps.readthedocs.io/en/latest/docs/Resources/troubleshooting.html#dealing-with-the-carelink-usb-stick).
-* 512/712 users - make sure you follow the additional instructions for the 512/712 before asking for help troubleshooting. You have a few additional steps you need to do.
 
 ## Running commands manually to see what's not working from an oref0-setup.sh setup process
   


### PR DESCRIPTION
The entire x12-users.md page is deprecated as of the 0.7.0 release, since it can pull all of this data directly from the pump. I've also made edits to other pages that make reference to it.