### PR TITLE
Fix link to Medtronic system "enlite-sensor"

### DIFF
--- a/docs/docs/Gear Up/CGM.md
+++ b/docs/docs/Gear Up/CGM.md
@@ -1,9 +1,9 @@
 # Information about compatible CGMs
-OpenAPS currently primarily supports three different CGM systems: 
-* the Dexcom G4 Platinum system (with or without the [Share](http://www.dexcom.com/dexcom-g4-platinum-share) functionality), 
+OpenAPS currently primarily supports these different CGM systems: 
+* the Dexcom G4 Platinum system (with or without the Share functionality), 
 * the Dexcom G5 system
 * the Dexcom G6 system
-* the [Medtronic system](https://www.medtronicdiabetes.com/treatments/continuous-glucose-monitoring) (MiniMed Paradigm REAL-Time Revel or Enlite),  
+* the older Medtronic CGM system (MiniMed Paradigm REAL-Time Revel or Enlite),  
 * and other CGM or CGM-like devices (Abbott's FreeStyle Libre) if the data is uploaded to Nightscout and the OpenAPS rig has Internet connectivity.
 
 With Dexcom G4, the Share platform is not required; but is valuable for uploading BG data to the cloud (and into Nightscout, which can then send BGs to the rig). However, without Share, a G4 receiver can instead be plugged in directly to the OpenAPS rig. For Dexcom G5 Mobile you can also use a compatible receiver (software upgraded G4 with Share receiver or a G5 Mobile Receiver), or also pull data from the Dexcom Share servers into Nightscout for use with an Internet-connected OpenAPS rig.

--- a/docs/docs/Gear Up/CGM.md
+++ b/docs/docs/Gear Up/CGM.md
@@ -3,7 +3,7 @@ OpenAPS currently primarily supports three different CGM systems:
 * the Dexcom G4 Platinum system (with or without the [Share](http://www.dexcom.com/dexcom-g4-platinum-share) functionality), 
 * the Dexcom G5 system
 * the Dexcom G6 system
-* the [Medtronic system](https://www.medtronicdiabetes.com/treatment-and-products/enlite-sensor) (MiniMed Paradigm REAL-Time Revel or Enlite),  
+* the [Medtronic system](https://www.medtronicdiabetes.com/treatments/continuous-glucose-monitoring) (MiniMed Paradigm REAL-Time Revel or Enlite),  
 * and other CGM or CGM-like devices (Abbott's FreeStyle Libre) if the data is uploaded to Nightscout and the OpenAPS rig has Internet connectivity.
 
 With Dexcom G4, the Share platform is not required; but is valuable for uploading BG data to the cloud (and into Nightscout, which can then send BGs to the rig). However, without Share, a G4 receiver can instead be plugged in directly to the OpenAPS rig. For Dexcom G5 Mobile you can also use a compatible receiver (software upgraded G4 with Share receiver or a G5 Mobile Receiver), or also pull data from the Dexcom Share servers into Nightscout for use with an Internet-connected OpenAPS rig.


### PR DESCRIPTION
Redirecting to the CGM page (https://www.medtronicdiabetes.com/download-library/enlite-sensor is of interest too maybe)