### PR TITLE
Add profile permissions for token auth

### DIFF
--- a/docs/docs/Customize-Iterate/useful-mobile-apps.md
+++ b/docs/docs/Customize-Iterate/useful-mobile-apps.md
@@ -129,7 +129,7 @@ Perhaps a more slightly advanced-user (or curious-user) feature of SimpleSSH is 
 
 ## SerialBot (Android)
 
-This app is useful for logging into the rig via a terminal session when not near a computer or using offline looping, can be done via USB serial cable, bluetooth or wifi depending on your setup. Simply selecrt the connection method using the drop down box and type in the rigs connection details.
+This app is useful for logging into the rig via a terminal session when not near a computer or using offline looping, can be done via USB serial cable, bluetooth or wifi depending on your setup. Simply select the connection method using the drop down box and type in the rig's connection details.
 For SSH use the format root@yourigname/ipaddress:22
 This app will use the same commands as other terminal session apps such as PuTTy.
 

--- a/docs/docs/While You Wait For Gear/monitoring-OpenAPS.md
+++ b/docs/docs/While You Wait For Gear/monitoring-OpenAPS.md
@@ -411,7 +411,7 @@ example picture:
 
     ```
     Make sure to replace the password, with your rig's password, and 192.168.1.20 with the ip/hostname of your rig.
-1) run chainsaw by the command: bin\chainsaw.bat (pc) or bin\chainsaw (linux and mac)
+1) run chainsaw by the command: bin\chainsaw.bat (pc) or bin/chainsaw (linux and mac)
 1) From the file menu choose 'load chainsaw configuration'
 1) Choose use chainsaw configuration file.
 1) press open file.

--- a/docs/docs/While You Wait For Gear/nightscout-setup.md
+++ b/docs/docs/While You Wait For Gear/nightscout-setup.md
@@ -268,14 +268,16 @@ If you want to secure your Nightscout and CGM data, then all rigs need to have o
 
     Name: `oref0rig`
 
-    Permissions:  Add the following 6 permissions. Note that the default window is too small to see them all after you paste them in.
+    Permissions:  Add the following 8 permissions. Note that the default window is too small to see them all after you paste them in.
     ```
     api:devicestatus:create, 
     api:devicestatus:read, 
     api:entries:create, 
     api:entries:read, 
     api:treatments:create, 
-    api:treatments:read
+    api:treatments:read, 
+    api:profile:create, 
+    api:profile:read
     ```
 
     ![AddRole](../Images/nightscout/role-oref0rig.png)


### PR DESCRIPTION
Additional permissions need to be assigned in Nightscout for oref0-upload-profile.sh to work with token auth.

Also fixed a few typos.