### PR TITLE
there is no step 4

### DIFF
--- a/docs/docs/Customize-Iterate/bluetooth-tethering-edison.md
+++ b/docs/docs/Customize-Iterate/bluetooth-tethering-edison.md
@@ -115,7 +115,7 @@ root@edisonhost:~# bluetoothd --version
    `sudo service cron stop`
 
 <details>
-    <summary>3) If you are using Jubilinux 0.3.0 (Debian Stretch) or the Raspberry Pi, please skip to #4. <b>If you are using Jubilinux 0.2.0 (Debian Jessie), you will need to manually initialize bluetooth. (click here to expand instructions)</b></summary>
+    <summary>3) If you are using Jubilinux 0.3.0 (Debian Stretch) or the Raspberry Pi, please skip to #4. WHERE is Step 4 ? <b>If you are using Jubilinux 0.2.0 (Debian Jessie), you will need to manually initialize bluetooth. (click here to expand instructions)</b></summary>
 <br>
 
    a) Restart the Bluetooth daemon to start up the bluetooth services.  (This is normally done automatically by oref0-online once everything is set up, but we want to do things manually this first time):


### PR DESCRIPTION
"If you are using Jubilinux 0.3.0 (Debian Stretch) or the Raspberry Pi, please skip to #4. If you are using Jubilinux 0.2.0 (Debian Jessie), you will need to manually initialize bluetooth. (click here to expand instructions)"

There is no step 4 that  I can find ... 
What are the steps for  Jubilinux 0.3.0 ?