### PR TITLE
must use " dev" command to avoid python 2.7 error

### DIFF
--- a/docs/docs/Build Your Rig/pi-install.md
+++ b/docs/docs/Build Your Rig/pi-install.md
@@ -60,7 +60,7 @@ Once you're logged in, run the following commands to start the OpenAPS install p
 
 ```
 sudo bash
-curl -s https://raw.githubusercontent.com/openaps/oref0/master/bin/openaps-install.sh > /tmp/openaps-install.sh && bash /tmp/openaps-install.sh
+curl -s https://raw.githubusercontent.com/openaps/oref0/master/bin/openaps-install.sh > /tmp/openaps-install.sh && bash /tmp/openaps-install.sh dev
 ```
 
 * Change your hostname (a.k.a, your rig's name). **Make sure to write down your hostname; this is how you will log in in the future as `ssh root@whatyounamedit.local`**


### PR DESCRIPTION
Using Raspiberry Pi Zero + Explorer HAT, when performing openaps install, it stuck in the middle due to an error related with python version, as error message below:

Mock requires python ‘>=3.6’ but the running python is 2.7.16

At the Gitter, @samueldimers2 pointed the solution, where we must use the dev version, add the " dev" argument to the end of the install command as below:

curl -s https://raw.githubusercontent.com/openaps/oref0/master/bin/openaps-install.sh > /tmp/openaps-install.sh && bash /tmp/openaps-install.sh dev

I did it and worked fine, being possible to install openaps