### PR TITLE
Added my name to those working on closed loops

### DIFF
--- a/docs/docs/While You Wait For Gear/loops-in-progress.md
+++ b/docs/docs/While You Wait For Gear/loops-in-progress.md
@@ -315,3 +315,4 @@ List of people who are working on closed loops:
 - Martin Fredheim (Oslo, Norway)
 - John Clifton (Sussex, UK)
 - Pam Kavanagh (Kildare, Ireland)
+- Nigel Lund (Adelaide, Australia)


### PR DESCRIPTION
Medtronic 754 with v2.6A firmware. Just switched from Medtronic Enlite CGMS to Dexcom G5. Have all required H/W for Edison based 1st rig. Edison now flashed with required Jubilinux. Both initial soft and 3D printed case prototypes are ready to go. Currently focused on accuracy of pump settings and tuning for loop startup. Outstanding H/W for backup RPi0W based rigs anticipated to arrive shortly.