### PR TITLE
rewind, prime and battery indicates change

### DIFF
--- a/docs/docs/While You Wait For Gear/preferences-and-safety-settings.md
+++ b/docs/docs/While You Wait For Gear/preferences-and-safety-settings.md
@@ -340,13 +340,13 @@ Defaults to false. Using the pump bolus wizard to enter carbs will prevent SMBs 
 
 #### rewind_indicates_cartridge_change
 
-Defaults to false. If true, assumes reservoir and insulin have been replaced and resets Insulin Age (IAGE) on nightscout 
+Defaults to false. If true, assumes reservoir and insulin have been replaced and resets Insulin Age (IAGE) on nightscout.
 
 #### prime_indicates_pump_site_change
 
-Defaults to false. If true, assumes cannula has been replaced and resets Cannula Age (CAGE) on nightscout 
+Defaults to false. If true, assumes cannula has been replaced after a fixed prime (ignores manual primes) and resets Cannula Age (CAGE) on nightscout.
 
 #### battery_indicates_battery_change
 
-Defaults to false. If true, assumes battery has been replaced and resets Battery Age (BAGE) on nightscout 
+Defaults to false. If true, assumes battery has been replaced and resets Battery Age (BAGE) on nightscout.
 

--- a/docs/docs/While You Wait For Gear/preferences-and-safety-settings.md
+++ b/docs/docs/While You Wait For Gear/preferences-and-safety-settings.md
@@ -337,3 +337,16 @@ Defaults to false, which means by default only the low end of the pump's BG targ
 Defaults to false. Using the pump bolus wizard to enter carbs will prevent SMBs from being enabled for COB as long as those carbs are active. Using the pump bolus wizard will prevent SMBs from being enabled for up to 6 hours by the "after carbs" or "always" preferences. If anyone wants to get around that, they can add A52_risk_enable (with the capital A) to preferences and set it to "true" to acknowledge and intentionally use that approach, which we know leads to increased A52 errors.
 
 (the recommended method for using SMBs is to enter carbs via NS and easy bolus any desired up-front insulin (generally less than the full amount that would be recommended by the bolus wizard) and then let SMB fill in the rest as it is safe to do so. For situations where the bolus wizard is preferred, such as for carb entry by inexperienced caregivers, or for offline use, we feel that it is safer for OpenAPS to disable SMBs and fall back to AMA until the next meal. In addition to reducing the risk of A52 errors, disabling SMBs when the bolus wizard is in use leads to more predictable AMA behavior (instead of SMB zero-temping) for untrained caregivers in an environment that is usually more prone to walk-away pump communication issues.)
+
+#### rewind_indicates_cartridge_change
+
+Defaults to false. If true, assumes reservoir and insulin have been replaced and resets Insulin Age (IAGE) on nightscout 
+
+#### prime_indicates_pump_site_change
+
+Defaults to false. If true, assumes cannula has been replaced and resets Cannula Age (CAGE) on nightscout 
+
+#### battery_indicates_battery_change
+
+Defaults to false. If true, assumes battery has been replaced and resets Battery Age (BAGE) on nightscout 
+


### PR DESCRIPTION
Added optional preferences to enable automatice update of Cannula, Insulin and Battery Age on Nightscout.