### PR TITLE
Update pi-install.md

### DIFF
--- a/docs/docs/Build Your Rig/pi-install.md
+++ b/docs/docs/Build Your Rig/pi-install.md
@@ -2,13 +2,13 @@
 
 ### Download Raspbian and write it to your microSD card ###
 
-Following the [install instructions](https://www.raspberrypi.org/documentation/installation/installing-images/README.md), download Raspbian Lite (you do **not** want Raspbian Desktop) and write it to an microSD card using Etcher.
+Following the [install instructions](https://www.raspberrypi.org/documentation/installation/installing-images/README.md), download Raspbian Lite (you do **not** want Raspbian Desktop) and write it to an microSD card using [Raspberry Pi Imager](https://www.raspberrypi.com/documentation/computers/getting-started.html#using-raspberry-pi-imager).
 
 ### Place your wifi and ssh configs on the new microSD card ###
 
-Once Etcher has finished writing the image to the microSD card, remove the microSD card from your computer and plug it right back in, so the boot partition shows up in Finder / Explorer.
+Once Raspberry Pi Imager has finished writing the image to the microSD card, remove the microSD card from your computer and plug it right back in, so the boot partition shows up in Finder / Explorer. (You may need to restart your computer for the microSD card with the boot drive to show up.)
 
-Create a file named wpa_supplicant.conf on the boot drive, with your wifi network(s) configured.  The file must be in a Unix format.  If creating the file in Windows, use an editor that allows you to save the file in Unix format instead of DOS format. There are many editors with this ability. `Notepad++` is one that works well. The file should look something like:
+Create a file named `wpa_supplicant.conf` on the boot drive, with your wifi network(s) configured.  The file must be in a Unix format.  If creating the file in Windows, use an editor that allows you to save the file in Unix format instead of DOS format. There are many editors with this ability. `Notepad++` is one that works well. The file should look something like:
 
 ```
 country=xx


### PR DESCRIPTION
Remove mention of Etcher and instead suggest Raspberry Pi Imager as the recommended app to use to install Pi OS to an SD card. (And add ticks around wpa_supplicant.conf filename.)