### PR TITLE
install from dev; add optional while loop to retry flashall.sh

### DIFF
--- a/docs/docs/Build Your Rig/edison-install.md
+++ b/docs/docs/Build Your Rig/edison-install.md
@@ -48,8 +48,8 @@ ifdown wlan0; ifup wlan0
 sleep 10
 echo -ne "\nWifi SSID: "; iwgetid -r
 sleep 5
-curl https://raw.githubusercontent.com/openaps/oref0/master/bin/openaps-install.sh > /tmp/openaps-install.sh
-bash /tmp/openaps-install.sh
+curl https://raw.githubusercontent.com/openaps/oref0/dev/bin/openaps-install.sh > /tmp/openaps-install.sh
+bash /tmp/openaps-install.sh dev
 )
 ```
 

--- a/docs/docs/Resources/Edison-Flashing/all-computers-flash.md
+++ b/docs/docs/Resources/Edison-Flashing/all-computers-flash.md
@@ -92,11 +92,15 @@ Windows PCs with less than 6 GB of RAM  may need to have the size of the page fi
 
 ## Flashing image onto the Edison
 
+Sometimes, particularly on older Edisons, the flash process will error out during the `Flashing rootfs, (it can take up to 10 minutes... Please be patient)` step, with `bytesdfu-util: Error during download`. If you retry the flash, it will get a bit further each time, until eventually it succeeds. Most likely, the Edison is finding bad SSD sectors and marking them, but not before the flash process errors out.
+
 ### If you’re using a Raspberry Pi - starting flash:
   - In the "flash window" from the Download Image instructions above, run `sudo ./flashall.sh`.  If you receive an `dfu-util: command not found` error, you can install dfu-util by running `sudo apt-get install dfu-util`
+ - If you want the flashall.sh script to keep retrying until it succeeds, you can do `while (sudo ./flashall.sh | tee /tmp/flash.out; grep Error /tmp/flash.out); do echo "Flash failed: retrying"; sleep 5; done`
 
 ### If you’re using a Mac - starting flash:
-  - In the "flash window" from the Download Image instructions above, run `./flashall.sh`.  
+  - In the "flash window" from the Download Image instructions above, run `./flashall.sh`.
+  - If you want the flashall.sh script to keep retrying until it succeeds, you can do `while (./flashall.sh | tee /tmp/flash.out; grep Error /tmp/flash.out); do echo "Flash failed: retrying"; sleep 5; done`  
     - If you receive an `dfu-util: command not found` error, you can install dfu-util by following [the Mac instructions here](https://software.intel.com/en-us/node/637974#manual-flash-process). 
     - If you receive an `Error: Running Homebrew as root is extremely dangerous and no longer supported. As Homebrew does not drop privileges on installation you would be giving all build scripts full access to your system.` see the troubleshooting section below.
 


### PR DESCRIPTION
Add optional while loop to retry flashall.sh until it succeeds.

Since github deprecated git:// URLs, the openaps-install.sh from the master branch no longer works.
Download openaps-install.sh from the dev branch, and install from the dev branch, until we release 0.7.1 to master.

