### PR TITLE
Second try at correcting the table

### DIFF
--- a/docs/docs/Gear Up/edison.md
+++ b/docs/docs/Gear Up/edison.md
@@ -106,13 +106,11 @@ Solder it to the board. It's the hole near the "o" from Radio. Make sure to not 
 
 This is your connection scheme for the RPi to RFM69HCW. Stick the RFM69HCW on a bread board, and connect:
 
-```
 | Board | Connect | Connect | Connect | Connect | Connect | Connect | Connect | Connect |
-| ------|------|------|------|------|------|------|------|------ |
-| RPi	| 3.3V	| GND	| MOSI | MISO | SCLK	| | CE1_N	||  |
-| RPi PIN	| 17	| 25	| 19	| 21	| 23	| 15	| 26	| 22 |
-| RFM69HCW	| VIN or 3.3V	| GND	| MOSI	| MISO	| SCK or CLK	| G0 or DIO0	| CS or NSS	| RST or RESET |
-```
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| RPi | 3.3V | GND | MOSI | MISO | SCLK | | CE1_N | |
+| RPi PIN | 17 | 25 | 19 | 21 | 23 | 15 | 26 | 22 |
+| RFM69HCW | VIN or 3.3V | GND | MOSI | MISO | SCK or CLK | G0 or DIO0 | CS or NSS | RST or RESET |
 
 ![Picture of RPI0WH with FM69HCW connection diagram](../Images/build-your-rig/rpii2RFM69HCW.JPG)
 


### PR DESCRIPTION
I didn't get to see what it looked like before the backticks were added (https://github.com/openaps/docs/commit/1dba918aa63bb0c616c9b61c3af933a0ac2eb651), so I don't know if it was enough to get the Read the Docs page formatted correctly, but obviously there's something else wrong since the PDF stuff broke. This is my second attempt. I realized that there were some inconsistencies in the use of spacing characters, and an extra column on one of the rows. Hopefully this attempt will work better. :crossed_fingers: